### PR TITLE
fix: 窗口模式缩放支持 1.0x（不缩放），让同分辨率滤镜真正 1:1

### DIFF
--- a/src/Magpie.Core/ScalingWindow.cpp
+++ b/src/Magpie.Core/ScalingWindow.cpp
@@ -963,12 +963,14 @@ bool ScalingWindow::_CalcWindowedScalingWindowSize(int& width, int& height, bool
 	const RECT& srcRect = _srcTracker.SrcRect();
 	const float srcAspectRatio = float(srcRect.bottom - srcRect.top) / (srcRect.right - srcRect.left);
 
-	// 计算最小尺寸时使用源窗口包含窗口框架的矩形而不是被缩放区域
-	const RECT& srcFrameRect = _srcTracker.WindowFrameRect();
-	const int spaceAround = (int)lroundf(WINDOWED_MODE_MIN_SPACE_AROUND *
+	// 计算最小尺寸时使用源窗口包含窗口框架的矩形而不是被缩放区域。用户显式指定 1.0x 时
+	// 不应放大画面，此时只要求渲染窗口不小于被缩放区域，从而做到逐像素对应。
+	const bool noUpscaling = _options.initialWindowedScaleFactor == 1.0f;
+	const RECT& minSrcRect = noUpscaling ? srcRect : _srcTracker.WindowFrameRect();
+	const int spaceAround = noUpscaling ? 0 : (int)lroundf(WINDOWED_MODE_MIN_SPACE_AROUND *
 		dpi / float(USER_DEFAULT_SCREEN_DPI));
-	const int minRendererWidth = srcFrameRect.right - srcFrameRect.left + spaceAround;
-	const int minRendererHeight = srcFrameRect.bottom - srcFrameRect.top + spaceAround;
+	const int minRendererWidth = minSrcRect.right - minSrcRect.left + spaceAround;
+	const int minRendererHeight = minSrcRect.bottom - minSrcRect.top + spaceAround;
 
 	int xExtraSpace;
 	int yExtraSpace;

--- a/src/Magpie/ProfilePage.xaml
+++ b/src/Magpie/ProfilePage.xaml
@@ -259,7 +259,7 @@
 						                VerticalAlignment="Stretch"
 						                Loaded="NumberBox_Loaded"
 						                Maximum="10"
-						                Minimum="1.1"
+						                Minimum="1"
 						                NumberFormatter="{x:Bind local:App.DoubleFormatter, Mode=OneTime}"
 						                SmallChange="0.1"
 						                Value="{x:Bind ViewModel.CustomInitialWindowedScaleFactor, Mode=TwoWay}" />


### PR DESCRIPTION
让窗口模式缩放可以真正设为 1.0x（不缩放），这样同分辨率滤镜（DLSSNR AI Filter、RTX Video 的降噪模式一类不负责放大的效果）可以在画面与源窗口逐像素对应、完全不经过重采样的前提下叠加。这条效果链原本必须先被放大至少 1.05x～1.1x，滤镜实际是在重采样后的画面上工作的。

同一改动已提给上游：Blinue/Magpie#1446 —— 这段代码本身来自上游，如果上游合并了，这个 PR 可以直接关掉。这里单独提一份是为了实验分支不用等上游。

## 问题

三处的下限并不一致：

1. `ProfilePage.xaml` 中「初始缩放倍数 → 自定义」的 `NumberBox` `Minimum="1.1"`。
2. `_CalcWindowedScalingWindowSize` 的最小渲染尺寸是「源窗口包含窗口框架的矩形 + `WINDOWED_MODE_MIN_SPACE_AROUND`(100dip)」，会把实际倍率顶到 1.05x 以上（源窗口带标题栏时更高），即使手改配置文件也会被静默覆盖。
3. 而 `AppSettings::_LoadProfile` 读取配置时是把 `customInitialWindowedScaleFactor` clamp 到 **1.0** 的，配置层本来就认为 1.0 合法。

## 改动

- `ProfilePage.xaml`：`NumberBox` 的 `Minimum` 由 1.1 改为 1。
- `ScalingWindow.cpp` / `_CalcWindowedScalingWindowSize`：仅当用户**显式**指定 1.0x 时，最小渲染尺寸以被缩放区域（`SrcRect`）为准且不额外留出空间。

其他倍率（含「自动」）行为不变，`WINDOWED_MODE_MIN_SPACE_AROUND` 常量未改动，`noUpscaling` 为 `false` 时这段代码与改动前等价。

## 测试

- `Release` / `x64` / MSVC v145（VS 2026），`EnableDLSSSR` + `EnableDLSSFrameGeneration` + `EnableDLSSNR` 打开，编译通过无警告。
- 在 1920x1080 窗口化游戏上用 `FrameRate_Filter` + `DLSSNR\DLSSNR_AI_Filter` 效果链实际使用过 1.0x：渲染窗口与被缩放区域尺寸一致，`DLSSNR STATUS` 正常，画面无重采样。
- 其他倍率和「自动」的表现与改动前一致。

## 已知取舍

1.0x 下渲染窗口只和被缩放区域一样大，缩放窗口靠自身的标题栏和边框遮挡源窗口。对标准窗口框架的源窗口基本刚好覆盖；源窗口自绘非客户区且尺寸差异较大时理论上可能露出边缘，这是选择「不缩放」可预期的结果。
