### PR TITLE
Live effect parameter editing in the scaling overlay

### DIFF
--- a/src/Magpie.Core/DLSSNRFilter.cpp
+++ b/src/Magpie.Core/DLSSNRFilter.cpp
@@ -891,6 +891,21 @@ DLSSNRFilter::GetFrameGuidanceRequirements() const noexcept {
 	return result;
 }
 
+NativeEffectParameterUpdate DLSSNRFilter::UpdateParameters(
+	const EffectOption& option
+) noexcept {
+	const DLSSNRSettings settings = ParseDLSSNRSettings(option);
+
+	// NR Preset 在创建特征时写入，只能通过重建生效。其余参数每帧提交给 NGX，
+	// 直接替换即可实时生效
+	if (settings.preset != _settings.preset) {
+		return NativeEffectParameterUpdate::NeedsRecreate;
+	}
+
+	_settings = settings;
+	return NativeEffectParameterUpdate::Applied;
+}
+
 bool DLSSNRFilter::Initialize(
 	DeviceResources& resources,
 	NgxD3D12Core& ngxCore,
@@ -1393,6 +1408,10 @@ bool DLSSNRFilter::Resize(
 	return false;
 }
 bool DLSSNRFilter::Drain() noexcept { return true; }
+NativeEffectParameterUpdate DLSSNRFilter::UpdateParameters(
+	const EffectOption&) noexcept {
+	return NativeEffectParameterUpdate::NeedsRecreate;
+}
 bool DLSSNRFilter::Draw(const NativeEffectDrawContext&) noexcept {
 	return false;
 }

--- a/src/Magpie.Core/DLSSNRFilter.h
+++ b/src/Magpie.Core/DLSSNRFilter.h
@@ -5,6 +5,7 @@ namespace Magpie {
 
 class DeviceResources;
 class NgxD3D12Core;
+struct EffectOption;
 
 struct DLSSNRSettings {
 	int preset = 0;
@@ -20,6 +21,9 @@ struct DLSSNRSettings {
 	uint32_t depthInferenceInterval = 4;
 };
 
+// 定义于 NativeEffectBackendFactory.cpp，创建和实时更新共用同一份解析逻辑
+DLSSNRSettings ParseDLSSNRSettings(const EffectOption& option) noexcept;
+
 // Experimental same-resolution DLSS neural filter. Magpie only owns the
 // composited colour frame, so valid zero-filled motion/depth textures are used
 // as explicit temporal guides.
@@ -34,6 +38,10 @@ public:
 
 	FrameGuidanceRequirements GetFrameGuidanceRequirements() const noexcept override;
 	bool Drain() noexcept override;
+
+	NativeEffectParameterUpdate UpdateParameters(
+		const EffectOption& option
+	) noexcept override;
 
 	bool Initialize(
 		DeviceResources& resources,

--- a/src/Magpie.Core/EffectDrawer.cpp
+++ b/src/Magpie.Core/EffectDrawer.cpp
@@ -325,6 +325,32 @@ bool EffectDrawer::ResizeTextures(
 	return true;
 }
 
+bool EffectDrawer::UpdateParameters(
+	const EffectDesc& desc,
+	const EffectOption& option,
+	DeviceResources& deviceResources
+) noexcept {
+	assert(!(desc.flags & EffectFlags::InlineParams));
+
+	if (_textures.size() < 2 || !_textures[0] || !_textures[1]) {
+		return false;
+	}
+
+	// 参数不参与尺寸表达式，因此直接沿用现有纹理的尺寸
+	D3D11_TEXTURE2D_DESC inputDesc;
+	_textures[0]->GetDesc(&inputDesc);
+	D3D11_TEXTURE2D_DESC outputDesc;
+	_textures[1]->GetDesc(&outputDesc);
+
+	return _UpdateConstants(
+		desc,
+		option,
+		deviceResources,
+		SIZE{ (LONG)inputDesc.Width, (LONG)inputDesc.Height },
+		SIZE{ (LONG)outputDesc.Width, (LONG)outputDesc.Height }
+	);
+}
+
 SIZE EffectDrawer::_CalcOutputSize(
 	const EffectDesc& desc,
 	const EffectOption& option,

--- a/src/Magpie.Core/EffectDrawer.h
+++ b/src/Magpie.Core/EffectDrawer.h
@@ -44,6 +44,14 @@ public:
 		ID3D11Texture2D** inOutTexture
 	) noexcept;
 
+	// 实时应用新的参数值。参数只影响常量缓冲区，纹理尺寸不受影响，因此无需重建资源。
+	// 内联参数的效果不能使用此方法，调用者应重新编译。
+	bool UpdateParameters(
+		const EffectDesc& desc,
+		const EffectOption& option,
+		DeviceResources& deviceResources
+	) noexcept;
+
 	ID3D11Texture2D* GetOutputTexture() const noexcept {
 		return _textures[1].get();
 	}

--- a/src/Magpie.Core/FrameGuidanceService.h
+++ b/src/Magpie.Core/FrameGuidanceService.h
@@ -48,6 +48,11 @@ public:
 	const FrameGuidanceView& ZeroView() const noexcept { return _zeroView; }
 	FrameGuidanceExtent SourceExtent() const noexcept { return _sourceExtent; }
 	bool IsInitialized() const noexcept { return _resources != nullptr; }
+	// 提供器只能在 Initialize 之前设置，实时调整参数时据此判断新的需求能否满足
+	bool HasDepthProvider() const noexcept { return _depthProvider != nullptr; }
+	bool HasMotionVectorProvider() const noexcept {
+		return _motionProvider != nullptr;
+	}
 
 private:
 	struct AdapterCache;

--- a/src/Magpie.Core/ImGuiFontsCacheManager.cpp
+++ b/src/Magpie.Core/ImGuiFontsCacheManager.cpp
@@ -139,7 +139,7 @@ struct serializer<
 namespace Magpie {
 
 // 缓存版本号。当缓存文件结构有更改时更新它，使旧缓存失效
-static constexpr uint32_t FONTS_CACHE_VERSION = 7;
+static constexpr uint32_t FONTS_CACHE_VERSION = 8;
 
 static std::wstring GetCacheFileName(const std::wstring_view& language, uint32_t dpi) noexcept {
 	return fmt::format(L"{}\\fonts_{}_{}", CommonSharedConstants::CACHE_DIR, language, dpi);

--- a/src/Magpie.Core/NativeEffectBackend.h
+++ b/src/Magpie.Core/NativeEffectBackend.h
@@ -4,6 +4,15 @@
 namespace Magpie {
 
 class DeviceResources;
+struct EffectOption;
+
+// 实时修改效果参数时后端的响应方式
+enum class NativeEffectParameterUpdate {
+	// 新参数已生效，无需重建
+	Applied,
+	// 参数在创建时写入，必须重建后端
+	NeedsRecreate
+};
 
 struct NativeEffectDrawContext {
 	ID3D11Texture2D* input = nullptr;
@@ -24,6 +33,14 @@ public:
 		return {};
 	}
 	virtual bool Drain() noexcept { return true; }
+
+	// 叠加层实时修改参数后调用，运行于后台线程。默认认为参数只能在创建时写入，
+	// Renderer 会重建后端，因此后端无需实现此方法也能正确响应参数变化。
+	virtual NativeEffectParameterUpdate UpdateParameters(
+		const EffectOption& /*option*/
+	) noexcept {
+		return NativeEffectParameterUpdate::NeedsRecreate;
+	}
 
 	virtual bool Resize(
 		DeviceResources& resources,

--- a/src/Magpie.Core/NativeEffectBackendFactory.cpp
+++ b/src/Magpie.Core/NativeEffectBackendFactory.cpp
@@ -30,6 +30,36 @@ static NativeEffectBackendResult CreateBackend(
 	return { true, std::move(backend) };
 }
 
+DLSSNRSettings ParseDLSSNRSettings(const EffectOption& option) noexcept {
+	auto getParameter = [&](std::string_view name, float defaultValue) {
+		auto it = option.parameters.find(std::string(name));
+		return it == option.parameters.end() ? defaultValue : it->second;
+	};
+
+	return DLSSNRSettings{
+		.preset = std::clamp(
+			static_cast<int>(std::lround(
+				getParameter("nrPreset", 0.0f))), 0, 3),
+		.style = std::clamp(
+			static_cast<int>(std::lround(getParameter("style", 0.0f))), 0, 2),
+		.intensity = std::clamp(getParameter("intensity", 1.0f), 0.0f, 2.0f),
+		.localToneStrength = std::clamp(
+			getParameter("localToneStrength", 1.0f), 0.0f, 2.0f),
+		.localStructureStrength = std::clamp(
+			getParameter("localStructureStrength", 1.0f), 0.0f, 2.0f),
+		.skinStructureStrength = std::clamp(
+			getParameter("skinStructureStrength", -1.0f), -1.0f, 2.0f),
+		.useAutoMask = getParameter("useAutoMask", 0.0f) >= 0.5f,
+		.uiCorrection = getParameter("uiCorrection", 0.0f) >= 0.5f,
+		.guidanceMode = std::clamp(
+			static_cast<int>(std::lround(
+				getParameter("guidanceMode", 0.0f))), 0, 3),
+		.depthInferenceInterval = static_cast<uint32_t>(std::clamp(
+			static_cast<int>(std::lround(
+				getParameter("depthInferenceInterval", 4.0f))), 1, 8))
+	};
+}
+
 NativeEffectBackendResult CreateNativeEffectBackend(
 	std::string_view effectName,
 	const EffectOption& option,
@@ -63,32 +93,7 @@ NativeEffectBackendResult CreateNativeEffectBackend(
 	}
 
 	if (effectName == "DLSSNR\\DLSSNR_AI_Filter") {
-		auto getParameter = [&](std::string_view name, float defaultValue) {
-			auto it = option.parameters.find(std::string(name));
-			return it == option.parameters.end() ? defaultValue : it->second;
-		};
-		DLSSNRSettings settings{
-			.preset = std::clamp(
-				static_cast<int>(std::lround(
-					getParameter("nrPreset", 0.0f))), 0, 3),
-			.style = std::clamp(
-				static_cast<int>(std::lround(getParameter("style", 0.0f))), 0, 2),
-			.intensity = std::clamp(getParameter("intensity", 1.0f), 0.0f, 2.0f),
-			.localToneStrength = std::clamp(
-				getParameter("localToneStrength", 1.0f), 0.0f, 2.0f),
-			.localStructureStrength = std::clamp(
-				getParameter("localStructureStrength", 1.0f), 0.0f, 2.0f),
-			.skinStructureStrength = std::clamp(
-				getParameter("skinStructureStrength", -1.0f), -1.0f, 2.0f),
-			.useAutoMask = getParameter("useAutoMask", 0.0f) >= 0.5f,
-			.uiCorrection = getParameter("uiCorrection", 0.0f) >= 0.5f,
-			.guidanceMode = std::clamp(
-				static_cast<int>(std::lround(
-					getParameter("guidanceMode", 0.0f))), 0, 3),
-			.depthInferenceInterval = static_cast<uint32_t>(std::clamp(
-				static_cast<int>(std::lround(
-					getParameter("depthInferenceInterval", 4.0f))), 1, 8))
-		};
+		const DLSSNRSettings settings = ParseDLSSNRSettings(option);
 		auto backend = std::make_unique<DLSSNRFilter>();
 		if (!backend->Initialize(resources, ngxCore, input, output, settings)) {
 			const char status[] =

--- a/src/Magpie.Core/OverlayDrawer.cpp
+++ b/src/Magpie.Core/OverlayDrawer.cpp
@@ -1111,39 +1111,45 @@ bool OverlayDrawer::_DrawEffectParameters(int& itemId) noexcept {
 
 			ImGui::PushID(itemId++);
 
-			bool changed = false;
+			// 参数可以声明为 float 或 int，取值范围统一按 float 处理
+			float minValue;
+			float maxValue;
+			float step;
+			bool isInteger;
 			if (param.constant.index() == 0) {
 				const EffectConstant<float>& constant = std::get<0>(param.constant);
-
-				ImGui::TextUnformatted(label.c_str());
-				ImGui::SetNextItemWidth(-FLT_MIN);
-				if (ImGui::SliderFloat("##value", &value,
-					constant.minValue, constant.maxValue, "%.2f")) {
-					if (constant.step > 0) {
-						value = constant.minValue + std::round(
-							(value - constant.minValue) / constant.step) * constant.step;
-					}
-					value = std::clamp(value, constant.minValue, constant.maxValue);
-					changed = true;
-				}
+				minValue = constant.minValue;
+				maxValue = constant.maxValue;
+				step = constant.step;
+				// 步长为 1 且边界是整数的浮点参数其实是整数，例如帧生成的倍数
+				isInteger = step == 1.0f && minValue == std::floor(minValue) &&
+					maxValue == std::floor(maxValue);
 			} else {
 				const EffectConstant<int>& constant = std::get<1>(param.constant);
-				int intValue = std::clamp(
-					(int)std::lround(value), constant.minValue, constant.maxValue);
+				minValue = (float)constant.minValue;
+				maxValue = (float)constant.maxValue;
+				step = (float)constant.step;
+				isInteger = true;
+			}
+
+			bool changed = false;
+			if (isInteger) {
+				const int intMin = (int)minValue;
+				const int intMax = (int)maxValue;
+				int intValue = std::clamp((int)std::lround(value), intMin, intMax);
 
 				std::string comboLabel;
 				SmallVector<std::string> items;
-				if (ParseLabelItems(label, constant.minValue,
-					constant.maxValue, comboLabel, items)) {
+				if (ParseLabelItems(label, intMin, intMax, comboLabel, items)) {
 					ImGui::TextUnformatted(comboLabel.c_str());
 					ImGui::SetNextItemWidth(-FLT_MIN);
 
-					const int selected = intValue - constant.minValue;
+					const int selected = intValue - intMin;
 					if (ImGui::BeginCombo("##value", items[selected].c_str())) {
 						for (int i = 0; i < (int)items.size(); ++i) {
 							const bool isSelected = i == selected;
 							if (ImGui::Selectable(items[i].c_str(), isSelected)) {
-								intValue = constant.minValue + i;
+								intValue = intMin + i;
 								changed = true;
 							}
 							if (isSelected) {
@@ -1152,7 +1158,7 @@ bool OverlayDrawer::_DrawEffectParameters(int& itemId) noexcept {
 						}
 						ImGui::EndCombo();
 					}
-				} else if (constant.minValue == 0 && constant.maxValue == 1) {
+				} else if (intMin == 0 && intMax == 1) {
 					bool boolValue = intValue != 0;
 					if (ImGui::Checkbox(label.c_str(), &boolValue)) {
 						intValue = boolValue ? 1 : 0;
@@ -1161,12 +1167,22 @@ bool OverlayDrawer::_DrawEffectParameters(int& itemId) noexcept {
 				} else {
 					ImGui::TextUnformatted(label.c_str());
 					ImGui::SetNextItemWidth(-FLT_MIN);
-					changed = ImGui::SliderInt("##value", &intValue,
-						constant.minValue, constant.maxValue);
+					changed = ImGui::SliderInt("##value", &intValue, intMin, intMax);
 				}
 
 				if (changed) {
 					value = (float)intValue;
+				}
+			} else {
+				ImGui::TextUnformatted(label.c_str());
+				ImGui::SetNextItemWidth(-FLT_MIN);
+				if (ImGui::SliderFloat("##value", &value, minValue, maxValue, "%.2f")) {
+					if (step > 0) {
+						value = minValue +
+							std::round((value - minValue) / step) * step;
+					}
+					value = std::clamp(value, minValue, maxValue);
+					changed = true;
 				}
 			}
 

--- a/src/Magpie.Core/OverlayDrawer.cpp
+++ b/src/Magpie.Core/OverlayDrawer.cpp
@@ -24,6 +24,7 @@ static const float CORNER_ROUNDING = 6;
 
 static const char* TOOLBAR_WINDOW_ID = "toolbar";
 static const char* PROFILER_WINDOW_ID = "profiler";
+static const char* EFFECT_PARAMETERS_WINDOW_ID = "effectParameters";
 
 static void SetDefaultWindowOptions(
 	phmap::flat_hash_map<std::string, OverlayWindowOption>& windowOptions
@@ -32,6 +33,16 @@ static void SetDefaultWindowOptions(
 		// 右侧竖直居中
 		windowOptions.emplace(PROFILER_WINDOW_ID, OverlayWindowOption{
 			.hArea = 2,
+			.vArea = 1,
+			.hPos = 60.0f,
+			.vPos = 0.5f
+		});
+	}
+
+	if (!windowOptions.contains(EFFECT_PARAMETERS_WINDOW_ID)) {
+		// 左侧竖直居中
+		windowOptions.emplace(EFFECT_PARAMETERS_WINDOW_ID, OverlayWindowOption{
+			.hArea = 0,
 			.vArea = 1,
 			.hPos = 60.0f,
 			.vPos = 0.5f
@@ -120,6 +131,10 @@ void OverlayDrawer::Draw(
 		if (_isProfilerVisible && _DrawProfiler(effectTimings, fps, itemId)) {
 			needRedraw = true;
 		}
+
+		if (_isEffectParametersVisible && _DrawEffectParameters(itemId)) {
+			needRedraw = true;
+		}
 			
 		if (needRedraw) {
 			++count;
@@ -179,7 +194,7 @@ void OverlayDrawer::ToolbarState(Magpie::ToolbarState value) noexcept {
 }
 
 bool OverlayDrawer::AnyVisibleWindow() const noexcept {
-	bool result = _isToolbarVisible || _isProfilerVisible;
+	bool result = _isToolbarVisible || _isProfilerVisible || _isEffectParametersVisible;
 #ifdef _DEBUG
 	result = result || _isDemoWindowVisible;
 #endif
@@ -741,6 +756,11 @@ bool OverlayDrawer::_DrawToolbar(uint32_t fps, int& itemId) noexcept {
 		ImGui::SameLine();
 		const std::string& profilerStr = _GetResourceString(L"Overlay_Toolbar_Profiler");
 		drawToggleButton(_isProfilerVisible, OverlayHelper::SegoeIcons::Diagnostic, profilerStr.c_str());
+		ImGui::SameLine();
+		const std::string& effectParamsStr =
+			_GetResourceString(L"Overlay_Toolbar_EffectParameters");
+		drawToggleButton(_isEffectParametersVisible,
+			OverlayHelper::SegoeIcons::Parameters, effectParamsStr.c_str());
 #ifdef _DEBUG
 		ImGui::SameLine();
 		const std::string& demoStr = _GetResourceString(L"Overlay_Toolbar_Demo");
@@ -909,6 +929,315 @@ static std::string RectToStr(const RECT& rect) noexcept {
 #endif
 
 // 返回 true 表示应再渲染一次
+// 部分效果把可选值写在标签里，例如 "NR Style (0 Default, 1 Natural, 2 Cinematic)"，
+// 解析成功后使用下拉框而不是滑块
+static bool ParseLabelItems(
+	std::string_view label,
+	int minValue,
+	int maxValue,
+	std::string& name,
+	SmallVector<std::string>& items
+) noexcept {
+	if (label.empty() || label.back() != ')' || minValue < 0 || maxValue <= minValue) {
+		return false;
+	}
+
+	const size_t lparen = label.rfind('(');
+	if (lparen == std::string_view::npos) {
+		return false;
+	}
+
+	std::string_view body = label.substr(lparen + 1, label.size() - lparen - 2);
+
+	items.clear();
+	int expected = minValue;
+	while (!body.empty()) {
+		const size_t comma = body.find(',');
+		std::string_view token = body.substr(0, comma);
+		body = comma == std::string_view::npos
+			? std::string_view{} : body.substr(comma + 1);
+
+		while (!token.empty() && token.front() == ' ') {
+			token.remove_prefix(1);
+		}
+		while (!token.empty() && token.back() == ' ') {
+			token.remove_suffix(1);
+		}
+
+		size_t digits = 0;
+		while (digits < token.size() && token[digits] >= '0' && token[digits] <= '9') {
+			++digits;
+		}
+		if (digits == 0 || digits >= token.size() || token[digits] != ' ') {
+			return false;
+		}
+
+		int value = 0;
+		for (size_t i = 0; i < digits; ++i) {
+			value = value * 10 + (token[i] - '0');
+		}
+		if (value != expected) {
+			return false;
+		}
+
+		items.emplace_back(token.substr(digits + 1));
+		++expected;
+	}
+
+	// 标签必须完整列出所有取值
+	if (expected != maxValue + 1) {
+		return false;
+	}
+
+	name = label.substr(0, lparen);
+	while (!name.empty() && name.back() == ' ') {
+		name.pop_back();
+	}
+	return true;
+}
+
+void OverlayDrawer::_InitEffectParameterValues() noexcept {
+	const std::vector<EffectOption>& effects = ScalingWindow::Get().Options().effects;
+	const std::vector<const EffectDesc*>& effectDescs =
+		ScalingWindow::Get().Renderer().ActiveEffectDescs();
+
+	// ActiveEffectDescs 可能包含追加的 Bicubic，它不属于缩放模式
+	const size_t effectCount = std::min(effects.size(), effectDescs.size());
+	_effectParameterValues.resize(effectCount);
+
+	for (size_t i = 0; i < effectCount; ++i) {
+		const EffectDesc& desc = *effectDescs[i];
+		std::vector<float>& values = _effectParameterValues[i];
+		values.resize(desc.params.size());
+
+		for (size_t j = 0; j < desc.params.size(); ++j) {
+			const EffectParameterDesc& param = desc.params[j];
+
+			// 缩放模式没有保存该参数时使用效果的默认值
+			float value = param.constant.index() == 0
+				? std::get<0>(param.constant).defaultValue
+				: (float)std::get<1>(param.constant).defaultValue;
+
+			if (auto it = effects[i].parameters.find(param.name);
+				it != effects[i].parameters.end()) {
+				value = it->second;
+			}
+
+			values[j] = value;
+		}
+	}
+}
+
+void OverlayDrawer::_SaveEffectParameters() noexcept {
+	const ScalingOptions& options = ScalingWindow::Get().Options();
+	if (!options.saveEffectParameters) {
+		return;
+	}
+
+	const std::vector<const EffectDesc*>& effectDescs =
+		ScalingWindow::Get().Renderer().ActiveEffectDescs();
+
+	std::vector<EffectOption> effects = options.effects;
+	for (size_t i = 0; i < _effectParameterValues.size() && i < effects.size(); ++i) {
+		const EffectDesc& desc = *effectDescs[i];
+		for (size_t j = 0; j < desc.params.size(); ++j) {
+			effects[i].parameters[desc.params[j].name] = _effectParameterValues[i][j];
+		}
+	}
+
+	options.saveEffectParameters(options.scalingModeIdx, effects);
+
+	ScalingWindow::Get().ShowToast(ScalingWindow::Get().GetLocalizedString(
+		L"Overlay_EffectParameters_Saved"));
+}
+
+bool OverlayDrawer::_DrawEffectParameters(int& itemId) noexcept {
+	const ScalingOptions& options = ScalingWindow::Get().Options();
+	Renderer& renderer = ScalingWindow::Get().Renderer();
+	const std::vector<const EffectDesc*>& effectDescs = renderer.ActiveEffectDescs();
+	const std::vector<bool>& canEditLive = renderer.CanEditEffectParametersLive();
+
+	if (_effectParameterValues.empty()) {
+		_InitEffectParameterValues();
+	}
+
+	bool needRedraw = false;
+
+	{
+		const float windowWidth = 340 * _dpiScale;
+		ImGui::SetNextWindowSizeConstraints(
+			ImVec2(windowWidth, 0.0f), ImVec2(windowWidth, 600 * _dpiScale));
+	}
+
+	const std::string title = StrHelper::Concat(
+		_GetResourceString(L"Overlay_EffectParameters"),
+		"##", EFFECT_PARAMETERS_WINDOW_ID);
+	if (!ImGui::Begin(title.c_str(), &_isEffectParametersVisible,
+		ImGuiWindowFlags_AlwaysAutoResize)) {
+		ImGui::End();
+		return needRedraw;
+	}
+
+	bool anyParameter = false;
+
+	for (size_t effectIdx = 0; effectIdx < _effectParameterValues.size(); ++effectIdx) {
+		const EffectDesc& desc = *effectDescs[effectIdx];
+		if (desc.params.empty()) {
+			continue;
+		}
+
+		anyParameter = true;
+
+		ImGui::PushID(itemId++);
+
+		const std::string& effectName = desc.sortName.empty() ? desc.name : desc.sortName;
+		ImGui::SeparatorText(effectName.c_str());
+
+		// 帧生成效果和内联参数的效果只有重新缩放才能应用新参数
+		const bool canEdit = effectIdx < canEditLive.size() && canEditLive[effectIdx];
+		if (!canEdit) {
+			ImGui::PushTextWrapPos();
+			ImGui::TextDisabled("%s", _GetResourceString(
+				L"Overlay_EffectParameters_RestartRequired").c_str());
+			ImGui::PopTextWrapPos();
+		}
+
+		ImGui::BeginDisabled(!canEdit);
+
+		for (size_t paramIdx = 0; paramIdx < desc.params.size(); ++paramIdx) {
+			const EffectParameterDesc& param = desc.params[paramIdx];
+			float& value = _effectParameterValues[effectIdx][paramIdx];
+			const std::string& label = param.label.empty() ? param.name : param.label;
+
+			ImGui::PushID(itemId++);
+
+			bool changed = false;
+			if (param.constant.index() == 0) {
+				const EffectConstant<float>& constant = std::get<0>(param.constant);
+
+				ImGui::TextUnformatted(label.c_str());
+				ImGui::SetNextItemWidth(-FLT_MIN);
+				if (ImGui::SliderFloat("##value", &value,
+					constant.minValue, constant.maxValue, "%.2f")) {
+					if (constant.step > 0) {
+						value = constant.minValue + std::round(
+							(value - constant.minValue) / constant.step) * constant.step;
+					}
+					value = std::clamp(value, constant.minValue, constant.maxValue);
+					changed = true;
+				}
+			} else {
+				const EffectConstant<int>& constant = std::get<1>(param.constant);
+				int intValue = std::clamp(
+					(int)std::lround(value), constant.minValue, constant.maxValue);
+
+				std::string comboLabel;
+				SmallVector<std::string> items;
+				if (ParseLabelItems(label, constant.minValue,
+					constant.maxValue, comboLabel, items)) {
+					ImGui::TextUnformatted(comboLabel.c_str());
+					ImGui::SetNextItemWidth(-FLT_MIN);
+
+					const int selected = intValue - constant.minValue;
+					if (ImGui::BeginCombo("##value", items[selected].c_str())) {
+						for (int i = 0; i < (int)items.size(); ++i) {
+							const bool isSelected = i == selected;
+							if (ImGui::Selectable(items[i].c_str(), isSelected)) {
+								intValue = constant.minValue + i;
+								changed = true;
+							}
+							if (isSelected) {
+								ImGui::SetItemDefaultFocus();
+							}
+						}
+						ImGui::EndCombo();
+					}
+				} else if (constant.minValue == 0 && constant.maxValue == 1) {
+					bool boolValue = intValue != 0;
+					if (ImGui::Checkbox(label.c_str(), &boolValue)) {
+						intValue = boolValue ? 1 : 0;
+						changed = true;
+					}
+				} else {
+					ImGui::TextUnformatted(label.c_str());
+					ImGui::SetNextItemWidth(-FLT_MIN);
+					changed = ImGui::SliderInt("##value", &intValue,
+						constant.minValue, constant.maxValue);
+				}
+
+				if (changed) {
+					value = (float)intValue;
+				}
+			}
+
+			if (changed) {
+				renderer.SetEffectParameter((uint32_t)effectIdx, param.name, value);
+				needRedraw = true;
+			}
+
+			ImGui::PopID();
+		}
+
+		ImGui::EndDisabled();
+		ImGui::PopID();
+	}
+
+	if (anyParameter) {
+		ImGui::Spacing();
+		ImGui::Separator();
+		ImGui::Spacing();
+
+		ImGui::PushID(itemId++);
+		if (ImGui::Button(_GetResourceString(
+			L"Overlay_EffectParameters_Revert").c_str())) {
+			_InitEffectParameterValues();
+
+			for (size_t i = 0; i < _effectParameterValues.size(); ++i) {
+				if (i >= canEditLive.size() || !canEditLive[i]) {
+					continue;
+				}
+
+				const EffectDesc& desc = *effectDescs[i];
+				for (size_t j = 0; j < desc.params.size(); ++j) {
+					renderer.SetEffectParameter((uint32_t)i,
+						desc.params[j].name, _effectParameterValues[i][j]);
+				}
+			}
+
+			needRedraw = true;
+		}
+		if (ImGui::IsItemHovered()) {
+			_imguiImpl.Tooltip(_GetResourceString(
+				L"Overlay_EffectParameters_Revert_Description").c_str(), _dpiScale);
+		}
+		ImGui::PopID();
+
+		ImGui::SameLine();
+
+		ImGui::PushID(itemId++);
+		ImGui::BeginDisabled(!options.saveEffectParameters);
+		if (ImGui::Button(_GetResourceString(
+			L"Overlay_EffectParameters_Save").c_str())) {
+			_SaveEffectParameters();
+			needRedraw = true;
+		}
+		ImGui::EndDisabled();
+		if (ImGui::IsItemHovered()) {
+			_imguiImpl.Tooltip(_GetResourceString(
+				L"Overlay_EffectParameters_Save_Description").c_str(), _dpiScale);
+		}
+		ImGui::PopID();
+	} else {
+		ImGui::PushTextWrapPos();
+		ImGui::TextUnformatted(_GetResourceString(
+			L"Overlay_EffectParameters_NoParameters").c_str());
+		ImGui::PopTextWrapPos();
+	}
+
+	ImGui::End();
+	return needRedraw;
+}
+
 bool OverlayDrawer::_DrawProfiler(const SmallVector<float>& effectTimings, uint32_t fps, int& itemId) noexcept {
 	const ScalingOptions& options = ScalingWindow::Get().Options();
 	const Renderer& renderer = ScalingWindow::Get().Renderer();

--- a/src/Magpie.Core/OverlayDrawer.h
+++ b/src/Magpie.Core/OverlayDrawer.h
@@ -81,6 +81,12 @@ private:
 
 	bool _DrawProfiler(const SmallVector<float>& effectTimings, uint32_t fps, int& itemId) noexcept;
 
+	bool _DrawEffectParameters(int& itemId) noexcept;
+
+	void _InitEffectParameterValues() noexcept;
+
+	void _SaveEffectParameters() noexcept;
+
 	const std::string& _GetResourceString(const std::wstring_view& key) noexcept;
 
 	float _CalcToolbarAlpha() const noexcept;
@@ -101,6 +107,9 @@ private:
 
 	SmallVector<uint32_t> _timelineColors;
 
+	// 各效果的参数当前值，第二层索引与 EffectDesc::params 一致
+	std::vector<std::vector<float>> _effectParameterValues;
+
 	struct {
 		std::string gpuName;
 	} _hardwareInfo;
@@ -116,6 +125,7 @@ private:
 	bool _isCursorOnCaptionArea = false;
 	bool _isToolbarItemActive = false;
 	bool _isProfilerVisible = false;
+	bool _isEffectParametersVisible = false;
 #ifdef _DEBUG
 	bool _isDemoWindowVisible = false;
 #endif

--- a/src/Magpie.Core/OverlayHelper.h
+++ b/src/Magpie.Core/OverlayHelper.h
@@ -61,6 +61,7 @@ struct OverlayHelper {
 		static const ImWchar FullScreen = 0xE740;
 		static const ImWchar Pinned = 0xE840;
 		static const ImWchar Diagnostic = 0xE9D9;
+		static const ImWchar Parameters = 0xE9E9;
 #ifdef _DEBUG
 		static const ImWchar Design = 0xEB3C;
 #endif
@@ -75,6 +76,7 @@ struct OverlayHelper {
 		SegoeIcons::FullScreen, SegoeIcons::FullScreen,
 		SegoeIcons::Pinned, SegoeIcons::Pinned,
 		SegoeIcons::Diagnostic, SegoeIcons::Diagnostic,
+		SegoeIcons::Parameters, SegoeIcons::Parameters,
 #ifdef _DEBUG
 		SegoeIcons::Design, SegoeIcons::Design,
 #endif

--- a/src/Magpie.Core/Renderer.cpp
+++ b/src/Magpie.Core/Renderer.cpp
@@ -64,6 +64,11 @@ static bool IsFrameGenerationEffect(std::string_view name) noexcept {
 	return IsDLSSFrameGenerationEffect(name) || IsXeSSFrameGenerationEffect(name);
 }
 
+// 目标帧率在初始化 StepTimer 时读取，之后修改无效
+static bool IsFrameRateFilterEffect(std::string_view name) noexcept {
+	return name == "FrameRate_Filter";
+}
+
 static double GetDisplayRefreshRate(HWND window) noexcept {
 	MONITORINFOEXW monitorInfo{};
 	monitorInfo.cbSize = sizeof(monitorInfo);
@@ -811,7 +816,9 @@ ID3D11Texture2D* Renderer::_BuildEffects() noexcept {
 	const ScalingOptions& options = ScalingWindow::Get().Options();
 	const bool noFP16 = !_backendResources.IsFP16Supported() || options.IsFP16Disabled();
 
-	const std::vector<EffectOption>& effects = options.effects;
+	// 保存一份副本，叠加层可以实时修改其中的参数
+	_effectOptions = options.effects;
+	const std::vector<EffectOption>& effects = _effectOptions;
 	assert(!effects.empty());
 	const uint32_t effectCount = (uint32_t)effects.size();
 
@@ -899,6 +906,16 @@ ID3D11Texture2D* Renderer::_BuildEffects() noexcept {
 		}
 	}
 	
+	_canEditEffectParametersLive.assign(effectCount, false);
+	for (uint32_t i = 0; i < effectCount; ++i) {
+		// 帧生成的参数决定共享纹理数量和呈现方式，只能在初始化时确定；内联参数
+		// 被编译进着色器，但原生后端直接读取参数，不受影响
+		_canEditEffectParametersLive[i] = !IsFrameGenerationEffect(effects[i].name) &&
+			!IsFrameRateFilterEffect(effects[i].name) &&
+			(_nativeEffectBackends[i] ||
+				!(_effectDescs[i].flags & EffectFlags::InlineParams));
+	}
+
 	if (_ShouldAppendBicubic(inOutTexture)) {
 		if (!_AppendBicubic(&inOutTexture)) {
 			Logger::Get().Error("_AppendBicubic 失败");
@@ -935,6 +952,115 @@ ID3D11Texture2D* Renderer::_BuildEffects() noexcept {
 	}
 
 	return inOutTexture;
+}
+
+void Renderer::SetEffectParameter(
+	uint32_t effectIdx,
+	std::string parameterName,
+	float value
+) noexcept {
+	if (!_backendThreadDispatcher) {
+		return;
+	}
+
+	// 参数只能在后台线程更新，拖动滑块产生的多次修改会合并到下一帧一并应用
+	_backendThreadDispatcher.TryEnqueue([this, effectIdx,
+		parameterName(std::move(parameterName)), value]() {
+		if (effectIdx >= _effectOptions.size()) {
+			return;
+		}
+
+		_effectOptions[effectIdx].parameters[parameterName] = value;
+
+		if (std::ranges::find(_dirtyEffectParameters, effectIdx) ==
+			_dirtyEffectParameters.end()) {
+			_dirtyEffectParameters.push_back(effectIdx);
+		}
+	});
+}
+
+void Renderer::_ApplyPendingEffectParameters() noexcept {
+	for (const uint32_t effectIdx : _dirtyEffectParameters) {
+		if (effectIdx >= _effectOptions.size()) {
+			continue;
+		}
+
+		const EffectOption& option = _effectOptions[effectIdx];
+
+		if (IsFrameGenerationEffect(option.name) ||
+			IsFrameRateFilterEffect(option.name)) {
+			// 叠加层会禁用这些效果的参数，正常情况下不会执行到这里
+			continue;
+		}
+
+		if (_nativeEffectBackends[effectIdx]) {
+			if (_nativeEffectBackends[effectIdx]->UpdateParameters(option) ==
+				NativeEffectParameterUpdate::NeedsRecreate) {
+				_RecreateNativeEffectBackend(effectIdx);
+			}
+		} else if (_effectDescs[effectIdx].flags & EffectFlags::InlineParams) {
+			// 参数已被编译进着色器，需重新编译整个效果链才能生效。叠加层会禁用
+			// 这些参数，正常情况下不会执行到这里
+			Logger::Get().Warn(fmt::format(
+				"效果#{} ({}) 内联了参数，无法实时调整", effectIdx, option.name));
+			continue;
+		} else if (!_effectDrawers[effectIdx].UpdateParameters(
+			_effectDescs[effectIdx], option, _backendResources)) {
+			Logger::Get().Error(fmt::format(
+				"更新效果#{} ({}) 的参数失败", effectIdx, option.name));
+		}
+	}
+
+	_dirtyEffectParameters.clear();
+
+	// 帧引导的提供器只能在初始化时创建，之后无法补充
+	if (!_loggedFrameGuidanceUnavailable) {
+		const FrameGuidanceRequirements requirements =
+			CollectFrameGuidanceRequirements(
+				_nativeEffectBackends, _dlssFrameGenerator.get());
+		if ((requirements.motion &&
+				!_frameGuidanceService.HasMotionVectorProvider()) ||
+			(requirements.depth && !_frameGuidanceService.HasDepthProvider())) {
+			_loggedFrameGuidanceUnavailable = true;
+			Logger::Get().Warn("Frame Guidance: provider unavailable for the new "
+				"parameters, restart scaling to apply");
+		}
+	}
+
+	// 源窗口静止时也应立刻看到调整结果
+	_forceNextRender = true;
+}
+
+bool Renderer::_RecreateNativeEffectBackend(uint32_t effectIdx) noexcept {
+	const EffectOption& option = _effectOptions[effectIdx];
+
+	if (!_DrainNgxConsumers()) {
+		Logger::Get().Error("Drain NGX consumers before recreating native effect failed");
+		return false;
+	}
+
+	// 必须先释放旧后端，SDK 特征独占资源
+	_nativeEffectBackends[effectIdx].reset();
+
+	NativeEffectBackendResult result = CreateNativeEffectBackend(
+		option.name,
+		option,
+		_backendResources,
+		_ngxD3D12Core,
+		_effectDrawers[effectIdx].GetTexture(0),
+		_effectDrawers[effectIdx].GetOutputTexture()
+	);
+	if (!result.backend) {
+		// 重建失败时该效果退化为直通，避免中断缩放
+		Logger::Get().Error(fmt::format(
+			"Recreate native effect {} failed", option.name));
+		return false;
+	}
+
+	_nativeEffectBackends[effectIdx] = std::move(result.backend);
+	Logger::Get().Info(fmt::format(
+		"Recreated native effect {} with new parameters", option.name));
+	return true;
 }
 
 void Renderer::_UpdateActiveEffectDescs() noexcept {
@@ -1011,7 +1137,8 @@ bool Renderer::_AppendBicubic(ID3D11Texture2D** inOutTexture) noexcept {
 
 ID3D11Texture2D* Renderer::_ResizeEffects() noexcept {
 	const ScalingOptions& options = ScalingWindow::Get().Options();
-	const std::vector<EffectOption>& effects = options.effects;
+	// 使用副本而不是 options.effects，否则实时调整的参数会被还原
+	const std::vector<EffectOption>& effects = _effectOptions;
 	assert(!effects.empty());
 	const uint32_t effectCount = (uint32_t)effects.size();
 	if (!_DrainNgxConsumers()) {
@@ -1379,6 +1506,10 @@ void Renderer::_BackendThreadProc() noexcept {
 			DispatchMessage(&msg);
 		}
 
+		if (!_dirtyEffectParameters.empty()) {
+			_ApplyPendingEffectParameters();
+		}
+
 		if (stepTimerStatus == StepTimerStatus::WaitForFPSLimiter) {
 			// 新帧消息可能已被处理，之后的 WaitForNextFrame 不要等待消息，直到状态变化
 			continue;
@@ -1387,7 +1518,8 @@ void Renderer::_BackendThreadProc() noexcept {
 		const FrameSourceState frameSourceState = _frameSource->Update();
 		switch (frameSourceState) {
 		case FrameSourceState::Waiting:
-			if (stepTimerStatus != StepTimerStatus::ForceNewFrame) {
+			// 参数刚刚改变时即使没有新的捕获帧也要渲染一次
+			if (stepTimerStatus != StepTimerStatus::ForceNewFrame && !_forceNextRender) {
 				if (fpsUpdated) {
 					// FPS 变化则要求前端重新渲染以更新叠加层，调整大小时这个操作十分必要
 					PostMessage(ScalingWindow::Get().Handle(),
@@ -1399,6 +1531,7 @@ void Renderer::_BackendThreadProc() noexcept {
 			// 强制帧
 			[[fallthrough]];
 		case FrameSourceState::NewFrame:
+			_forceNextRender = false;
 			_BackendRender(
 				_effectDrawers.back().GetOutputTexture(),
 				frameSourceState == FrameSourceState::NewFrame);

--- a/src/Magpie.Core/Renderer.cpp
+++ b/src/Magpie.Core/Renderer.cpp
@@ -64,9 +64,31 @@ static bool IsFrameGenerationEffect(std::string_view name) noexcept {
 	return IsDLSSFrameGenerationEffect(name) || IsXeSSFrameGenerationEffect(name);
 }
 
-// 目标帧率在初始化 StepTimer 时读取，之后修改无效
 static bool IsFrameRateFilterEffect(std::string_view name) noexcept {
 	return name == "FrameRate_Filter";
+}
+
+// 创建和实时更新共用同一份解析逻辑
+static DLSSFrameGenerationSettings ParseDLSSFrameGenerationSettings(
+	const EffectOption& option
+) noexcept {
+	auto getParameter = [&](std::string_view name, float defaultValue) {
+		auto it = option.parameters.find(std::string(name));
+		return it == option.parameters.end() ? defaultValue : it->second;
+	};
+
+	return DLSSFrameGenerationSettings{
+		.multiplier = std::clamp(
+			(uint32_t)std::lround(getParameter("multiplier", 2.0f)), 2u, 4u),
+		.useMotionVectors = getParameter("useMotionVectors", 1.0f) >= 0.5f,
+		.useEstimatedDepth = getParameter("useEstimatedDepth", 0.0f) >= 0.5f
+	};
+}
+
+static float ParseFrameRateFilterTarget(const EffectOption& option) noexcept {
+	auto it = option.parameters.find("targetFrameRate");
+	return std::clamp(
+		it == option.parameters.end() ? 60.0f : it->second, 1.0f, 240.0f);
 }
 
 static double GetDisplayRefreshRate(HWND window) noexcept {
@@ -334,10 +356,14 @@ bool Renderer::_OpenFrontendSharedTextures() noexcept {
 		_frontendSharedTextures[i] = nullptr;
 		_lastAccessMutexKeys[i] = 0;
 	}
-	for (uint32_t i = 0; i < _sharedTextureSlotCount; ++i) {
+	if (!_sharedTextureHandles[0]) {
+		Logger::Get().Error("DLSSFG shared presentation slot has no handle");
+		return false;
+	}
+	// 打开所有已分配的槽位，帧生成倍数可以在缩放期间改变
+	for (uint32_t i = 0; i < MAX_SHARED_TEXTURE_SLOTS; ++i) {
 		if (!_sharedTextureHandles[i]) {
-			Logger::Get().Error("DLSSFG shared presentation slot has no handle");
-			return false;
+			continue;
 		}
 		const HRESULT hr = _frontendResources.GetD3DDevice()->OpenSharedResource(
 			_sharedTextureHandles[i],
@@ -816,8 +842,7 @@ ID3D11Texture2D* Renderer::_BuildEffects() noexcept {
 	const ScalingOptions& options = ScalingWindow::Get().Options();
 	const bool noFP16 = !_backendResources.IsFP16Supported() || options.IsFP16Disabled();
 
-	// 保存一份副本，叠加层可以实时修改其中的参数
-	_effectOptions = options.effects;
+	// _effectOptions 是 options.effects 的副本，叠加层可以实时修改其中的参数
 	const std::vector<EffectOption>& effects = _effectOptions;
 	assert(!effects.empty());
 	const uint32_t effectCount = (uint32_t)effects.size();
@@ -885,19 +910,8 @@ ID3D11Texture2D* Renderer::_BuildEffects() noexcept {
 				Logger::Get().Error("Only one DLSS Frame Generation effect is allowed");
 				return nullptr;
 			}
-			auto getParameter = [&](std::string_view name, float defaultValue) {
-				auto it = effects[i].parameters.find(std::string(name));
-				return it == effects[i].parameters.end() ? defaultValue : it->second;
-			};
-			dlssFrameGenerationSettings = DLSSFrameGenerationSettings{
-				.multiplier = std::clamp(
-					(uint32_t)std::lround(getParameter("multiplier", 2.0f)),
-					2u, 4u),
-				.useMotionVectors =
-					getParameter("useMotionVectors", 1.0f) >= 0.5f,
-				.useEstimatedDepth =
-					getParameter("useEstimatedDepth", 0.0f) >= 0.5f
-			};
+			dlssFrameGenerationSettings =
+				ParseDLSSFrameGenerationSettings(effects[i]);
 		}
 
 		// 释放 CSO 内存，不再需要它们
@@ -910,9 +924,10 @@ ID3D11Texture2D* Renderer::_BuildEffects() noexcept {
 	for (uint32_t i = 0; i < effectCount; ++i) {
 		// 帧生成的参数决定共享纹理数量和呈现方式，只能在初始化时确定；内联参数
 		// 被编译进着色器，但原生后端直接读取参数，不受影响
-		_canEditEffectParametersLive[i] = !IsFrameGenerationEffect(effects[i].name) &&
-			!IsFrameRateFilterEffect(effects[i].name) &&
-			(_nativeEffectBackends[i] ||
+		// XeSS 帧生成通过独立的呈现器实现，其参数无法实时切换
+		_canEditEffectParametersLive[i] = !IsXeSSFrameGenerationEffect(effects[i].name) &&
+			(_nativeEffectBackends[i] || IsDLSSFrameGenerationEffect(effects[i].name) ||
+				IsFrameRateFilterEffect(effects[i].name) ||
 				!(_effectDescs[i].flags & EffectFlags::InlineParams));
 	}
 
@@ -987,9 +1002,19 @@ void Renderer::_ApplyPendingEffectParameters() noexcept {
 
 		const EffectOption& option = _effectOptions[effectIdx];
 
-		if (IsFrameGenerationEffect(option.name) ||
-			IsFrameRateFilterEffect(option.name)) {
-			// 叠加层会禁用这些效果的参数，正常情况下不会执行到这里
+		if (IsFrameRateFilterEffect(option.name)) {
+			// 目标帧率同时影响 StepTimer 和帧生成的呈现节奏
+			_UpdateFrameRateLimits();
+			continue;
+		}
+
+		if (IsDLSSFrameGenerationEffect(option.name)) {
+			_RebuildDLSSFrameGenerator();
+			continue;
+		}
+
+		if (IsXeSSFrameGenerationEffect(option.name)) {
+			// 叠加层会禁用这些参数，正常情况下不会执行到这里
 			continue;
 		}
 
@@ -1029,6 +1054,100 @@ void Renderer::_ApplyPendingEffectParameters() noexcept {
 
 	// 源窗口静止时也应立刻看到调整结果
 	_forceNextRender = true;
+}
+
+bool Renderer::_RebuildDLSSFrameGenerator() noexcept {
+	if (!_dlssFrameGenerator) {
+		// 本次缩放已禁用帧生成，重建没有意义
+		return false;
+	}
+
+	const auto it = std::ranges::find_if(_effectOptions,
+		[](const EffectOption& effect) {
+			return IsDLSSFrameGenerationEffect(effect.name);
+		});
+	if (it == _effectOptions.end()) {
+		return false;
+	}
+
+	// 呈现环按最大槽位数分配，因此倍数改变无需重建共享纹理
+	if (!_InitializeDLSSFrameGenerator(
+		_effectDrawers.back().GetOutputTexture(),
+		ParseDLSSFrameGenerationSettings(*it))) {
+		Logger::Get().Error("Rebuild DLSSFG with the new parameters failed");
+		_DisableDLSSFrameGenerationForSession();
+		return false;
+	}
+
+	_sharedTextureSlotCount = std::clamp(
+		_dlssFrameGenerator->Multiplier(), 2u, MAX_SHARED_TEXTURE_SLOTS);
+	_dlssFgConsecutiveFailures = 0;
+	_dlssFgRecoveryAttempts = 0;
+	_ResetDLSSFGSlotEvents();
+	_lastSynchronousPresentTime = {};
+
+	Logger::Get().Info(fmt::format(
+		"Rebuilt DLSSFG with the new parameters: multiplier={}x slots={}",
+		_dlssFrameGenerator->Multiplier(), _sharedTextureSlotCount));
+	return true;
+}
+
+void Renderer::_UpdateSynchronousPresentInterval() noexcept {
+	if (_dlssFrameGenerator && _frameRateFilterTarget > 0.0f) {
+		const double outputFrameRate =
+			double(_frameRateFilterTarget) * _dlssFrameGenerator->Multiplier();
+		_synchronousPresentInterval = std::chrono::nanoseconds(
+			(int64_t)std::llround(1'000'000'000.0 / outputFrameRate));
+	} else {
+		_synchronousPresentInterval = {};
+	}
+}
+
+void Renderer::_UpdateFrameRateLimits() noexcept {
+	const ScalingOptions& options = ScalingWindow::Get().Options();
+
+	std::optional<float> maxFrameRate = _captureMaxFrameRate;
+
+	_frameRateFilterTarget = 0.0f;
+	for (const EffectOption& effect : _effectOptions) {
+		if (!IsFrameRateFilterEffect(effect.name)) {
+			continue;
+		}
+
+		const float targetFrameRate = ParseFrameRateFilterTarget(effect);
+		if (!maxFrameRate || targetFrameRate < *maxFrameRate) {
+			maxFrameRate = targetFrameRate;
+		}
+		_frameRateFilterTarget = _frameRateFilterTarget == 0.0f
+			? targetFrameRate
+			: std::min(_frameRateFilterTarget, targetFrameRate);
+		Logger::Get().Info(fmt::format(
+			"Frame Rate Filter enabled: {} FPS", targetFrameRate));
+	}
+
+	if (options.maxFrameRate) {
+		if (!maxFrameRate || *options.maxFrameRate < *maxFrameRate) {
+			maxFrameRate = options.maxFrameRate;
+		}
+	}
+
+	// 测试着色器性能时最小帧率应设为无限大，但由于 /fp:fast 下无限大不可靠，因此改为使用 max()，
+	// 和无限大效果相同。
+	const bool useFrameGeneration = std::ranges::any_of(
+		_effectOptions,
+		[](const EffectOption& effect) { return IsFrameGenerationEffect(effect.name); });
+	const float minFrameRate = useFrameGeneration
+		? 0.0f
+		: (options.IsBenchmarkMode()
+			? std::numeric_limits<float>::max() : options.minFrameRate);
+	if (useFrameGeneration &&
+		(options.minFrameRate > 0 || options.IsBenchmarkMode())) {
+		Logger::Get().Info(
+			"Frame Generation: minimum-FPS duplicate frame synthesis disabled");
+	}
+
+	_stepTimer.Initialize(minFrameRate, maxFrameRate);
+	_UpdateSynchronousPresentInterval();
 }
 
 bool Renderer::_RecreateNativeEffectBackend(uint32_t effectIdx) noexcept {
@@ -1261,14 +1380,6 @@ bool Renderer::_InitializeDLSSFrameGenerator(
 		{ sourceDesc.Width, sourceDesc.Height }, settings)) {
 		return false;
 	}
-	if (_frameRateFilterTarget > 0.0f) {
-		const double outputFrameRate =
-			double(_frameRateFilterTarget) * frameGenerator->Multiplier();
-		_synchronousPresentInterval = std::chrono::nanoseconds(
-			(int64_t)std::llround(1'000'000'000.0 / outputFrameRate));
-	} else {
-		_synchronousPresentInterval = {};
-	}
 	const double refreshRate = GetDisplayRefreshRate(ScalingWindow::Get().Handle());
 	const double theoreticalOutput = _frameRateFilterTarget > 0.0f ?
 		double(_frameRateFilterTarget) * frameGenerator->Multiplier() : 0.0;
@@ -1297,6 +1408,7 @@ bool Renderer::_InitializeDLSSFrameGenerator(
 	_dlssFgRealPublishSuccess = 0;
 	_dlssFgRealPublishFailure = 0;
 	_dlssFrameGenerator = std::move(frameGenerator);
+	_UpdateSynchronousPresentInterval();
 	return true;
 }
 
@@ -1403,6 +1515,9 @@ HANDLE Renderer::_CreateSharedTexture(ID3D11Texture2D* effectsOutput) noexcept {
 	D3D11_TEXTURE2D_DESC desc;
 	effectsOutput->GetDesc(&desc);
 	SIZE textureSize = { (LONG)desc.Width, (LONG)desc.Height };
+	// 按最大槽位数分配，这样实时改变帧生成倍数时无需重建共享纹理
+	const uint32_t slotCapacity =
+		_dlssFrameGenerator ? MAX_SHARED_TEXTURE_SLOTS : 1u;
 	_sharedTextureSlotCount = _dlssFrameGenerator ?
 		std::clamp(_dlssFrameGenerator->Multiplier(), 2u, MAX_SHARED_TEXTURE_SLOTS) : 1u;
 	_sharedTextureGeneration.fetch_add(1, std::memory_order_release);
@@ -1416,7 +1531,7 @@ HANDLE Renderer::_CreateSharedTexture(ID3D11Texture2D* effectsOutput) noexcept {
 		_sharedTextureMutexKeys[i].store(0, std::memory_order_relaxed);
 	}
 
-	for (uint32_t i = 0; i < _sharedTextureSlotCount; ++i) {
+	for (uint32_t i = 0; i < slotCapacity; ++i) {
 		_backendSharedTextures[i] = DirectXHelper::CreateTexture2D(
 			_backendResources.GetD3DDevice(),
 			DXGI_FORMAT_R8G8B8A8_UNORM,
@@ -1580,6 +1695,9 @@ HANDLE Renderer::_InitBackend() noexcept {
 		_backendThreadDispatcher = dqc.DispatcherQueue();
 	}
 
+	// 保存一份副本，叠加层可以实时修改其中的参数
+	_effectOptions = ScalingWindow::Get().Options().effects;
+
 	if (!_backendResources.Initialize(false)) {
 		return NULL;
 	}
@@ -1591,7 +1709,6 @@ HANDLE Renderer::_InitBackend() noexcept {
 		return NULL;
 	}
 	{
-		std::optional<float> maxFrameRate;
 		if (_frameSource->WaitType() == FrameSourceWaitType::NoWait) {
 			// 某些捕获方式不会限制捕获帧率，因此将捕获帧率限制为屏幕刷新率
 			const HWND hwndSrc = ScalingWindow::Get().SrcTracker().Handle();
@@ -1604,52 +1721,12 @@ HANDLE Renderer::_InitBackend() noexcept {
 
 				if (dm.dmDisplayFrequency > 0) {
 					Logger::Get().Info(fmt::format("屏幕刷新率: {}", dm.dmDisplayFrequency));
-					maxFrameRate = float(dm.dmDisplayFrequency);
+					_captureMaxFrameRate = float(dm.dmDisplayFrequency);
 				}
 			}
 		}
 
-		const ScalingOptions& options = ScalingWindow::Get().Options();
-		for (const EffectOption& effect : options.effects) {
-			if (effect.name != "FrameRate_Filter") {
-				continue;
-			}
-			auto it = effect.parameters.find("targetFrameRate");
-			const float targetFrameRate = std::clamp(
-				it == effect.parameters.end() ? 60.0f : it->second,
-				1.0f,
-				240.0f
-			);
-			if (!maxFrameRate || targetFrameRate < *maxFrameRate) {
-				maxFrameRate = targetFrameRate;
-			}
-			_frameRateFilterTarget = _frameRateFilterTarget == 0.0f
-				? targetFrameRate
-				: std::min(_frameRateFilterTarget, targetFrameRate);
-			Logger::Get().Info(fmt::format(
-				"Frame Rate Filter enabled: {} FPS", targetFrameRate));
-		}
-		if (options.maxFrameRate) {
-			if (!maxFrameRate || *options.maxFrameRate < *maxFrameRate) {
-				maxFrameRate = options.maxFrameRate;
-			}
-		}
-		
-		// 测试着色器性能时最小帧率应设为无限大，但由于 /fp:fast 下无限大不可靠，因此改为使用 max()，
-		// 和无限大效果相同。
-		const bool useFrameGeneration = std::ranges::any_of(
-			options.effects,
-			[](const EffectOption& effect) { return IsFrameGenerationEffect(effect.name); });
-		const float minFrameRate = useFrameGeneration
-			? 0.0f
-			: (options.IsBenchmarkMode()
-				? std::numeric_limits<float>::max() : options.minFrameRate);
-		if (useFrameGeneration &&
-			(options.minFrameRate > 0 || options.IsBenchmarkMode())) {
-			Logger::Get().Info(
-				"Frame Generation: minimum-FPS duplicate frame synthesis disabled");
-		}
-		_stepTimer.Initialize(minFrameRate, maxFrameRate);
+		_UpdateFrameRateLimits();
 	}
 
 	ID3D11Texture2D* outputTexture = _BuildEffects();

--- a/src/Magpie.Core/Renderer.h
+++ b/src/Magpie.Core/Renderer.h
@@ -57,6 +57,19 @@ public:
 		return _activeEffectDescs;
 	}
 
+	// 实时修改效果参数，可由前台线程调用。同一帧内的多次修改会合并后应用
+	void SetEffectParameter(
+		uint32_t effectIdx,
+		std::string parameterName,
+		float value
+	) noexcept;
+
+	// 各效果的参数能否实时调整，索引与 ScalingOptions::effects 一致。
+	// 和 _activeEffectDescs 一样在后台初始化期间填充，之后只读
+	const std::vector<bool>& CanEditEffectParametersLive() const noexcept {
+		return _canEditEffectParametersLive;
+	}
+
 	void StartProfile() noexcept;
 
 	void StopProfile() noexcept;
@@ -106,6 +119,10 @@ private:
 	bool _AppendBicubic(ID3D11Texture2D** inOutTexture) noexcept;
 
 	ID3D11Texture2D* _ResizeEffects() noexcept;
+
+	void _ApplyPendingEffectParameters() noexcept;
+
+	bool _RecreateNativeEffectBackend(uint32_t effectIdx) noexcept;
 
 	void _UpdateDestRect() noexcept;
 
@@ -170,6 +187,13 @@ private:
 	FrameGuidanceFrameId _capturedFrameId = 0;
 	NgxD3D12Core _ngxD3D12Core;
 	std::vector<EffectDrawer> _effectDrawers;
+	// options.effects 的副本，叠加层实时修改的参数保存在这里
+	std::vector<EffectOption> _effectOptions;
+	// 参数已改变、等待应用的效果
+	SmallVector<uint32_t> _dirtyEffectParameters;
+	// 参数改变后即使没有新的捕获帧也应渲染一次
+	bool _forceNextRender = false;
+	bool _loggedFrameGuidanceUnavailable = false;
 	std::vector<std::unique_ptr<class NativeEffectBackend>> _nativeEffectBackends;
 	std::unique_ptr<class DLSSFrameGenerator> _dlssFrameGenerator;
 	uint32_t _dlssFgConsecutiveFailures = 0;
@@ -233,6 +257,7 @@ private:
 	std::vector<EffectDesc> _effectDescs;
 	// 包含追加的 Bicubic
 	std::vector<const EffectDesc*> _activeEffectDescs;
+	std::vector<bool> _canEditEffectParametersLive;
 };
 
 }

--- a/src/Magpie.Core/Renderer.h
+++ b/src/Magpie.Core/Renderer.h
@@ -124,6 +124,13 @@ private:
 
 	bool _RecreateNativeEffectBackend(uint32_t effectIdx) noexcept;
 
+	bool _RebuildDLSSFrameGenerator() noexcept;
+
+	// 根据当前的效果参数重新计算帧率限制，初始化和实时调整时都会调用
+	void _UpdateFrameRateLimits() noexcept;
+
+	void _UpdateSynchronousPresentInterval() noexcept;
+
 	void _UpdateDestRect() noexcept;
 
 	HANDLE _CreateSharedTexture(ID3D11Texture2D* effectsOutput) noexcept;
@@ -227,6 +234,8 @@ private:
 	std::atomic<uint32_t> _sharedTextureGeneration = 0;
 	std::atomic<bool> _synchronousFramePresentationEnabled = false;
 	float _frameRateFilterTarget = 0.0f;
+	// 捕获方式和屏幕刷新率决定的帧率上限，不随效果参数改变
+	std::optional<float> _captureMaxFrameRate;
 	std::chrono::nanoseconds _synchronousPresentInterval{};
 	std::chrono::steady_clock::time_point _lastSynchronousPresentTime{};
 	uint32_t _dlssFgFrontendTimingFrames = 0;

--- a/src/Magpie.Core/StepTimer.cpp
+++ b/src/Magpie.Core/StepTimer.cpp
@@ -7,6 +7,11 @@ namespace Magpie {
 
 void StepTimer::Initialize(float minFrameRate, std::optional<float> maxFrameRate) noexcept {
 	assert(minFrameRate >= 0);
+
+	// 实时调整帧率限制时会再次调用，因此必须先还原为初始状态
+	_minInterval = {};
+	_maxInterval = nanoseconds::max();
+
 	if (minFrameRate > 0) {
 		_maxInterval = duration_cast<nanoseconds>(duration<float>(1 / minFrameRate));
 	}

--- a/src/Magpie.Core/include/ScalingOptions.h
+++ b/src/Magpie.Core/include/ScalingOptions.h
@@ -191,6 +191,8 @@ struct ScalingOptions {
 	DEFINE_FLAG_ACCESSOR(IsDirectFlipDisabled, ScalingFlags::DisableDirectFlip, flags)
 
 	std::vector<EffectOption> effects;
+	// 缩放模式在设置中的索引，叠加层据此将实时调整的参数写回
+	uint32_t scalingModeIdx = 0;
 	uint32_t flags = ScalingFlags::AdjustCursorSpeed;
 	Cropping cropping{};
 	GraphicsCardId graphicsCardId;
@@ -214,6 +216,11 @@ struct ScalingOptions {
 	void (*showToast)(HWND hwndTarget, std::wstring_view msg) noexcept = nullptr;
 	void (*showError)(HWND hwndTarget, ScalingError error) noexcept = nullptr;
 	void (*save)(const ScalingOptions& options, HWND hwndScaling) noexcept = nullptr;
+	// 将叠加层中实时调整的效果参数写回缩放模式
+	void (*saveEffectParameters)(
+		uint32_t scalingModeIdx,
+		const std::vector<EffectOption>& effects
+	) noexcept = nullptr;
 
 	void Log() const noexcept;
 

--- a/src/Magpie/Resources.language-en-US.resw
+++ b/src/Magpie/Resources.language-en-US.resw
@@ -907,6 +907,33 @@
   <data name="Overlay_Toolbar_Profiler" xml:space="preserve">
     <value>Profiler Window</value>
   </data>
+  <data name="Overlay_Toolbar_EffectParameters" xml:space="preserve">
+    <value>Effect Parameters Window</value>
+  </data>
+  <data name="Overlay_EffectParameters" xml:space="preserve">
+    <value>Effect Parameters</value>
+  </data>
+  <data name="Overlay_EffectParameters_NoParameters" xml:space="preserve">
+    <value>The current scaling mode has no adjustable parameters.</value>
+  </data>
+  <data name="Overlay_EffectParameters_RestartRequired" xml:space="preserve">
+    <value>These parameters take effect only after restarting scaling.</value>
+  </data>
+  <data name="Overlay_EffectParameters_Revert" xml:space="preserve">
+    <value>Revert</value>
+  </data>
+  <data name="Overlay_EffectParameters_Revert_Description" xml:space="preserve">
+    <value>Restore the values the scaling mode started with</value>
+  </data>
+  <data name="Overlay_EffectParameters_Save" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="Overlay_EffectParameters_Save_Description" xml:space="preserve">
+    <value>Write the current values back to the scaling mode</value>
+  </data>
+  <data name="Overlay_EffectParameters_Saved" xml:space="preserve">
+    <value>Parameters saved to the scaling mode</value>
+  </data>
   <data name="Message_Windowed3DGameMode" xml:space="preserve">
     <value>Windowed scaling is not supported in 3D game mode.</value>
   </data>

--- a/src/Magpie/Resources.language-zh-Hans.resw
+++ b/src/Magpie/Resources.language-zh-Hans.resw
@@ -907,6 +907,33 @@
   <data name="Overlay_Toolbar_Profiler" xml:space="preserve">
     <value>性能分析器窗口</value>
   </data>
+  <data name="Overlay_Toolbar_EffectParameters" xml:space="preserve">
+    <value>效果参数窗口</value>
+  </data>
+  <data name="Overlay_EffectParameters" xml:space="preserve">
+    <value>效果参数</value>
+  </data>
+  <data name="Overlay_EffectParameters_NoParameters" xml:space="preserve">
+    <value>当前缩放模式没有可调整的参数。</value>
+  </data>
+  <data name="Overlay_EffectParameters_RestartRequired" xml:space="preserve">
+    <value>这些参数需重新缩放才能生效。</value>
+  </data>
+  <data name="Overlay_EffectParameters_Revert" xml:space="preserve">
+    <value>还原</value>
+  </data>
+  <data name="Overlay_EffectParameters_Revert_Description" xml:space="preserve">
+    <value>恢复为开始缩放时的参数值</value>
+  </data>
+  <data name="Overlay_EffectParameters_Save" xml:space="preserve">
+    <value>保存</value>
+  </data>
+  <data name="Overlay_EffectParameters_Save_Description" xml:space="preserve">
+    <value>将当前参数值写回缩放模式</value>
+  </data>
+  <data name="Overlay_EffectParameters_Saved" xml:space="preserve">
+    <value>参数已保存到缩放模式</value>
+  </data>
   <data name="Message_Windowed3DGameMode" xml:space="preserve">
     <value>3D 游戏模式下不支持窗口模式缩放。</value>
   </data>

--- a/src/Magpie/ScalingService.cpp
+++ b/src/Magpie/ScalingService.cpp
@@ -9,6 +9,7 @@
 #include "ScalingModesService.h"
 #include "ScalingService.h"
 #include "ShortcutService.h"
+#include "StrHelper.h"
 #include "ToastService.h"
 #include "TouchHelper.h"
 #include "Win32Helper.h"
@@ -359,6 +360,7 @@ ScalingError ScalingService::_StartScaleImpl(HWND hWnd, const Profile& profile, 
 	for (const EffectItem& effectItem : effects) {
 		options.effects.push_back((EffectOption)effectItem);
 	}
+	options.scalingModeIdx = (uint32_t)profile.scalingMode;
 
 	// 尝试启用触控支持
 	bool isTouchSupportEnabled;
@@ -493,6 +495,42 @@ ScalingError ScalingService::_StartScaleImpl(HWND hWnd, const Profile& profile, 
 		App::Get().Dispatcher().TryEnqueue(
 			[overlayOptions(options.overlayOptions)]() {
 				AppSettings::Get().OverlayOptions() = std::move(overlayOptions);
+				AppSettings::Get().SaveAsync();
+			}
+		);
+	};
+
+	options.saveEffectParameters = [](
+		uint32_t scalingModeIdx,
+		const std::vector<EffectOption>& effects
+	) noexcept {
+		App::Get().Dispatcher().TryEnqueue(
+			[scalingModeIdx, effects]() {
+				if (scalingModeIdx >= ScalingModesService::Get().GetScalingModeCount()) {
+					return;
+				}
+
+				ScalingMode& scalingMode =
+					ScalingModesService::Get().GetScalingMode(scalingModeIdx);
+				if (scalingMode.effects.size() != effects.size()) {
+					// 缩放模式在缩放期间被修改
+					return;
+				}
+
+				for (size_t i = 0; i < effects.size(); ++i) {
+					EffectItem& effectItem = scalingMode.effects[i];
+					if (effectItem.name != StrHelper::UTF8ToUTF16(effects[i].name)) {
+						return;
+					}
+				}
+
+				for (size_t i = 0; i < effects.size(); ++i) {
+					EffectItem& effectItem = scalingMode.effects[i];
+					for (const auto& [name, value] : effects[i].parameters) {
+						effectItem.parameters[StrHelper::UTF8ToUTF16(name)] = value;
+					}
+				}
+
 				AppSettings::Get().SaveAsync();
 			}
 		);


### PR DESCRIPTION
Adds an **Effect Parameters** window to the scaling overlay, so effect parameters can be tuned while scaling instead of stopping scaling, editing the scaling mode, and starting again.

![toolbar](https://raw.githubusercontent.com/Kristijan1001/Magpie-TensorRT/pr-assets/img/live-effect-parameters/toolbar.png)

![panel](https://raw.githubusercontent.com/Kristijan1001/Magpie-TensorRT/pr-assets/img/live-effect-parameters/panel.png)

## UI

The window is generated from `EffectDesc::params`, so every effect is covered without per-effect UI code:

- labels that enumerate their values, e.g. `NR Style (0 Default, 1 Natural, 2 Cinematic)`, become combo boxes
- 0/1 integers become checkboxes
- floats declared with `STEP 1` and integral bounds — how frame generation declares its multiplier and toggles — get integer sliders
- everything else is a slider snapped to the declared step

`Revert` restores the values the scaling session started with. `Save` writes the current values back into the scaling mode through a new `ScalingOptions::saveEffectParameters` callback.

## How changes are applied

Edits are posted to the backend thread, coalesced per frame, and applied before the next render. A render is forced afterwards so the result is visible even when the source window is static.

| Effect | Path |
| --- | --- |
| Shader effects | `EffectDrawer::UpdateParameters` rewrites the constant buffer; parameters never affect texture sizes, so no resources are rebuilt |
| DLSSNR | Everything except NR Preset is submitted to NGX every frame, so it is swapped in place; NR Preset recreates the feature |
| Other native SDK backends | `NativeEffectBackend::UpdateParameters` defaults to recreating the backend, so a backend responds correctly without implementing anything |
| DLSS Frame Generation | The feature is rebuilt in place — `_InitializeDLSSFrameGenerator` was already called at runtime by the failure-recovery path |
| Frame Rate Filter | `_UpdateFrameRateLimits` retunes `StepTimer` and the DLSSFG pacing interval |

To make the frame generation multiplier changeable, the presentation ring is now allocated at `MAX_SHARED_TEXTURE_SLOTS` whenever frame generation is active, and the frontend opens every allocated slot. A multiplier change then only moves `_sharedTextureSlotCount` instead of renegotiating shared textures. `StepTimer::Initialize` resets its intervals first so it can run more than once.

Parameters that genuinely cannot change mid-session — XeSS frame generation, and shader effects compiled with inline parameters — are shown disabled with a note that scaling must be restarted.

The backend now keeps its own copy of the effect options, so resizing the scaling window no longer reverts live edits.

## Strings

Added to `Resources.language-en-US.resw` and `Resources.language-zh-Hans.resw`. `FONTS_CACHE_VERSION` is bumped because the toolbar button adds an icon glyph (E9E9, the same one the scaling modes page uses for parameters).

## Testing

Built with MSVC x64 and tested on an RTX 5080 against the DLSSNR and DLSSFG scaling modes.

- DLSSNR: NR Intensity, Style, Local Tone/Structure and Skin Structure change the image immediately; NR Preset rebuilds the feature with a brief hitch.
- DLSSFG: multiplier, Use Motion Vectors, Use Estimated Depth and Target Frame Rate rebuild the generator and retune pacing.

Two notes about CI, both pre-existing and unrelated to this change:

- `build.yml` provisions no SDKs, so `EnableDLSSSR` / `EnableDLSSFrameGeneration` / `EnableDLSSNR` are false there and the native paths above are not exercised by CI builds. I tested with the public NVIDIA DLSS headers and import library provisioned in the workflow.
- `ARM64 + ClangCL` currently fails on `experimental` with `-Werror,-Wunused-private-field` on ten fields in `DLSSSRUpscaler.h` and `DLSSNRFilter.h`, files this PR does not touch. Happy to send a separate fix for that.
