### PR TITLE
fix(depth): stabilize TensorRT depth inference

### DIFF
--- a/src/Magpie.Core/DepthInferenceBackend.cpp
+++ b/src/Magpie.Core/DepthInferenceBackend.cpp
@@ -73,8 +73,11 @@ public:
 			ORT_LOGGING_LEVEL_WARNING,
 			_tensorRT ? "MagpieDAV2TensorRT" : "MagpieDAV2DirectML", &_env)) ||
 			!_Check(_api->CreateSessionOptions(&_sessionOptions)) ||
+			// ORT_ENABLE_BASIC: SimplifiedLayerNormFusion 在 DAV2 模型上触发 ORT
+			// graph_utils.cc GetIndexFromName 断言（TRT EP 分区路径），降级到 BASIC 绕开；
+			// TRT EP 有自己的 kernel，扩展级图融合收益极小
 			!_Check(_api->SetSessionGraphOptimizationLevel(
-				_sessionOptions, ORT_ENABLE_ALL)) ||
+				_sessionOptions, ORT_ENABLE_BASIC)) ||
 			!_Check(_api->AddFreeDimensionOverrideByName(
 				_sessionOptions, "batch_size", 1)) ||
 			!_Check(_api->AddFreeDimensionOverrideByName(
@@ -179,9 +182,10 @@ private:
 		const std::string deviceId = std::to_string(config.adapterIndex);
 		const std::string fixedShape = fmt::format(
 			"pixel_values:1x3x{}x{}", config.inputHeight, config.inputWidth);
+		// 布尔键必须用 True/False（与官方 ORT TRT EP 的解析保持一致）
 		const char* values[]{
-			deviceId.c_str(), "1", "0", "1", cachePath.c_str(),
-			"1", cachePath.c_str(), "0", "3",
+			deviceId.c_str(), "True", "False", "True", cachePath.c_str(),
+			"True", cachePath.c_str(), "False", "3",
 			fixedShape.c_str(), fixedShape.c_str(), fixedShape.c_str()
 		};
 		const bool result = _Check(_api->UpdateTensorRTProviderOptions(


### PR DESCRIPTION
## 概述

修复 DAV2 深度推理在 TensorRT Execution Provider 初始化阶段的稳定性和官方 ONNX Runtime 兼容性问题。

## 修改内容

- 将 Session 图优化等级从 `ORT_ENABLE_ALL` 降为 `ORT_ENABLE_BASIC`。
  - 避免 `SimplifiedLayerNormFusion` 在 DAV2 模型的 TensorRT 分区路径中触发 `graph_utils.cc / GetIndexFromName` 失败。
  - TensorRT EP 自身提供相关 kernel，跳过扩展级图融合对该路径的收益影响很小。
- 将 TensorRT EP 的五个布尔选项从 `"1"/"0"` 改为 `"True"/"False"`。
  - 覆盖 `trt_fp16_enable`、`trt_int8_enable`、`trt_engine_cache_enable`、`trt_timing_cache_enable` 和 `trt_engine_hw_compatible`。
  - 与官方 ONNX Runtime TensorRT Provider 的选项解析格式保持一致。

## 原因

`ORT_ENABLE_ALL` 会启用扩展级图融合；在当前 DAV2 ONNX 模型上，`SimplifiedLayerNormFusion` 可能生成后续分区阶段无法按名称解析的节点。部分 ORT 构建会返回错误，当前部署使用的定制构建在同一路径上可能直接访问违例。降为 BASIC 可以绕过该融合。

官方 TensorRT EP 的布尔选项解析要求 `True/False`；使用 `1/0` 依赖定制构建的宽松行为，在切换到官方 ORT 时会因选项格式无效而失败。

## 验证

- PR 相对 `experimental` 仅包含 1 个提交、1 个文件。
- `git diff --check` 通过。
- 已对部署版执行等效二进制修补并完成字节范围及反汇编静态验证。
- 本 PR 未重新执行完整源码构建或 GPU 端到端运行测试。