### PR TITLE
fix(build/ui/ux): ClangCL no-SDK 构建报错修复 + preset 参数键与反馈链接修正 + 缩放开始 toast + 一致性检查套件（基于 upstream/experimental 9824d758）

### DIFF
--- a/presets/ScalingModes-v0.5.7-experimental.json
+++ b/presets/ScalingModes-v0.5.7-experimental.json
@@ -12,7 +12,7 @@
         {
           "name": "DLSSFG\\DLSS_FrameGeneration",
           "parameters": {
-            "frameMultiplier": 2,
+            "multiplier": 2,
             "useMotionVectors": 1,
             "useEstimatedDepth": 0
           }

--- a/src/Magpie.Core/AdaptivePresenter.h
+++ b/src/Magpie.Core/AdaptivePresenter.h
@@ -53,7 +53,8 @@ private:
 	bool _isResized = false;
 	FrameLatencyGate _frameLatencyGate;
 	bool _isSwitchingToSwapChain = false;
-	uint32_t _frameLatencyWaitTimeoutCount = 0;
+	// 当前未被任何代码读取（等待超时计数未接线）；ClangCL -Werror、-Wunused-private-field 会报错
+	[[maybe_unused]] uint32_t _frameLatencyWaitTimeoutCount = 0;
 	uint32_t _presentOccludedCount = 0;
 	uint32_t _presentFailureCount = 0;
 };

--- a/src/Magpie.Core/AmdOpticalFlowProvider.h
+++ b/src/Magpie.Core/AmdOpticalFlowProvider.h
@@ -29,7 +29,8 @@ public:
 	OpticalFlowInitializationError InitializationError() const noexcept override;
 
 private:
-	AmdOpticalFlowMode _mode;
+	// 仅在 MP_ENABLE_AMD_OPTICAL_FLOW 构建中使用；无 SDK 的 CI 构建里 ClangCL -Werror 会报未使用
+	[[maybe_unused]] AmdOpticalFlowMode _mode;
 	std::unique_ptr<Impl> _impl;
 };
 

--- a/src/Magpie.Core/DLSSFrameGenerator.h
+++ b/src/Magpie.Core/DLSSFrameGenerator.h
@@ -54,7 +54,8 @@ public:
 	uint32_t MaxSupportedMultiplier() const noexcept;
 
 private:
-	std::unique_ptr<Impl> _impl;
+	// 仅在 MP_ENABLE_DLSS_FRAME_GENERATION 构建中使用；无 SDK 的 CI 构建里 ClangCL -Werror 会报未使用
+	[[maybe_unused]] std::unique_ptr<Impl> _impl;
 	DLSSFrameGenerationSettings _requestedSettings{};
 };
 

--- a/src/Magpie.Core/DLSSNRFilter.h
+++ b/src/Magpie.Core/DLSSNRFilter.h
@@ -69,9 +69,10 @@ public:
 	bool Draw(const NativeEffectDrawContext& context) noexcept override;
 
 private:
-	std::unique_ptr<Impl> _impl;
-	DLSSNRSettings _settings;
-	NgxD3D12Core* _ngxCore = nullptr;
+	// 仅在 MP_ENABLE_DLSSNR 构建中使用；无 SDK 的 CI 构建里 ClangCL -Werror 会报未使用
+	[[maybe_unused]] std::unique_ptr<Impl> _impl;
+	[[maybe_unused]] DLSSNRSettings _settings;
+	[[maybe_unused]] NgxD3D12Core* _ngxCore = nullptr;
 };
 
 }

--- a/src/Magpie.Core/DLSSSRUpscaler.h
+++ b/src/Magpie.Core/DLSSSRUpscaler.h
@@ -52,21 +52,23 @@ public:
 private:
 	void _Reset() noexcept;
 
-	ID3D11Device5* _device = nullptr;
-	ID3D11DeviceContext4* _d3dDC = nullptr;
-	winrt::com_ptr<ID3D11Texture2D> _zeroMotionVectors;
-	winrt::com_ptr<ID3D11UnorderedAccessView> _zeroMotionVectorsUav;
-	winrt::com_ptr<ID3D11Texture2D> _zeroDepth;
-	winrt::com_ptr<ID3D11UnorderedAccessView> _zeroDepthUav;
-	winrt::com_ptr<ID3D11Texture2D> _biasCurrentColorMask;
-	winrt::com_ptr<ID3D11UnorderedAccessView> _biasCurrentColorMaskUav;
-	void* _parameters = nullptr;
-	void* _feature = nullptr;
-	bool _ngxInitialized = false;
-	bool _resetHistory = true;
-	DLSSSRSettings _settings{};
-	uint8_t _lastGuidanceBinding = UINT8_MAX;
-	FrameGuidanceFrameId _lastGuidanceResetFrameId =
+	// 以下字段仅在 MP_ENABLE_DLSS_SR 构建中使用；无 SDK 的 CI 构建里
+	// ClangCL -Werror、-Wunused-private-field 会报错
+	[[maybe_unused]] ID3D11Device5* _device = nullptr;
+	[[maybe_unused]] ID3D11DeviceContext4* _d3dDC = nullptr;
+	[[maybe_unused]] winrt::com_ptr<ID3D11Texture2D> _zeroMotionVectors;
+	[[maybe_unused]] winrt::com_ptr<ID3D11UnorderedAccessView> _zeroMotionVectorsUav;
+	[[maybe_unused]] winrt::com_ptr<ID3D11Texture2D> _zeroDepth;
+	[[maybe_unused]] winrt::com_ptr<ID3D11UnorderedAccessView> _zeroDepthUav;
+	[[maybe_unused]] winrt::com_ptr<ID3D11Texture2D> _biasCurrentColorMask;
+	[[maybe_unused]] winrt::com_ptr<ID3D11UnorderedAccessView> _biasCurrentColorMaskUav;
+	[[maybe_unused]] void* _parameters = nullptr;
+	[[maybe_unused]] void* _feature = nullptr;
+	[[maybe_unused]] bool _ngxInitialized = false;
+	[[maybe_unused]] bool _resetHistory = true;
+	[[maybe_unused]] DLSSSRSettings _settings{};
+	[[maybe_unused]] uint8_t _lastGuidanceBinding = UINT8_MAX;
+	[[maybe_unused]] FrameGuidanceFrameId _lastGuidanceResetFrameId =
 		std::numeric_limits<FrameGuidanceFrameId>::max();
 };
 

--- a/src/Magpie.Core/FSR2Upscaler.h
+++ b/src/Magpie.Core/FSR2Upscaler.h
@@ -30,29 +30,31 @@ private:
 	MotionVectorRequest _motionRequest{};
 	void _Reset() noexcept;
 
-	ID3D11Device* _device = nullptr;
-	ID3D11DeviceContext4* _d3dDC = nullptr;
-	HMODULE _coreModule = nullptr;
-	HMODULE _backendModule = nullptr;
-	void* _context = nullptr;
-	void* _scratch = nullptr;
-	size_t _scratchSize = 0;
-	void* _contextCreate = nullptr;
-	void* _contextDestroy = nullptr;
-	void* _contextDispatch = nullptr;
-	void* _getInterface = nullptr;
-	void* _getScratchSize = nullptr;
-	void* _getDevice = nullptr;
-	void* _getResource = nullptr;
-	winrt::com_ptr<ID3D11Texture2D> _zeroMotion;
-	winrt::com_ptr<ID3D11UnorderedAccessView> _zeroMotionUav;
-	winrt::com_ptr<ID3D11Texture2D> _zeroDepth;
-	winrt::com_ptr<ID3D11UnorderedAccessView> _zeroDepthUav;
-	winrt::com_ptr<ID3D11Texture2D> _reactive;
-	winrt::com_ptr<ID3D11UnorderedAccessView> _reactiveUav;
-	bool _resetHistory = true;
-	FrameGuidanceFrameId _lastGuidanceResetFrameId = std::numeric_limits<FrameGuidanceFrameId>::max();
-	bool _enableOpticalFlow = false;
+	// 以下字段仅在 MP_ENABLE_FSR2_ZEROMV 构建中使用；无 SDK 的 CI 构建里
+	// ClangCL -Werror、-Wunused-private-field 会报错
+	[[maybe_unused]] ID3D11Device* _device = nullptr;
+	[[maybe_unused]] ID3D11DeviceContext4* _d3dDC = nullptr;
+	[[maybe_unused]] HMODULE _coreModule = nullptr;
+	[[maybe_unused]] HMODULE _backendModule = nullptr;
+	[[maybe_unused]] void* _context = nullptr;
+	[[maybe_unused]] void* _scratch = nullptr;
+	[[maybe_unused]] size_t _scratchSize = 0;
+	[[maybe_unused]] void* _contextCreate = nullptr;
+	[[maybe_unused]] void* _contextDestroy = nullptr;
+	[[maybe_unused]] void* _contextDispatch = nullptr;
+	[[maybe_unused]] void* _getInterface = nullptr;
+	[[maybe_unused]] void* _getScratchSize = nullptr;
+	[[maybe_unused]] void* _getDevice = nullptr;
+	[[maybe_unused]] void* _getResource = nullptr;
+	[[maybe_unused]] winrt::com_ptr<ID3D11Texture2D> _zeroMotion;
+	[[maybe_unused]] winrt::com_ptr<ID3D11UnorderedAccessView> _zeroMotionUav;
+	[[maybe_unused]] winrt::com_ptr<ID3D11Texture2D> _zeroDepth;
+	[[maybe_unused]] winrt::com_ptr<ID3D11UnorderedAccessView> _zeroDepthUav;
+	[[maybe_unused]] winrt::com_ptr<ID3D11Texture2D> _reactive;
+	[[maybe_unused]] winrt::com_ptr<ID3D11UnorderedAccessView> _reactiveUav;
+	[[maybe_unused]] bool _resetHistory = true;
+	[[maybe_unused]] FrameGuidanceFrameId _lastGuidanceResetFrameId = std::numeric_limits<FrameGuidanceFrameId>::max();
+	[[maybe_unused]] bool _enableOpticalFlow = false;
 };
 
 }

--- a/src/Magpie.Core/FSR3Upscaler.h
+++ b/src/Magpie.Core/FSR3Upscaler.h
@@ -33,8 +33,9 @@ public:
 
 private:
 	MotionVectorRequest _motionRequest{};
-	std::unique_ptr<Impl> _impl;
-	bool _useFsr4 = false;
+	// 仅在 MP_ENABLE_FSR3_ZEROMV 构建中使用；无 SDK 的 CI 构建里 ClangCL -Werror 会报未使用
+	[[maybe_unused]] std::unique_ptr<Impl> _impl;
+	[[maybe_unused]] bool _useFsr4 = false;
 };
 
 }

--- a/src/Magpie.Core/NgxD3D12Core.h
+++ b/src/Magpie.Core/NgxD3D12Core.h
@@ -37,9 +37,11 @@ private:
 	void _Shutdown() noexcept;
 
 	winrt::com_ptr<ID3D12Device> _device;
-	uint32_t _activeConsumers = 0;
-	uint32_t _activeParameterBlocks = 0;
-	bool _initialized = false;
+	// 以下字段只在各 SDK 门控后端(同一 TU 之外)中读取，本 TU 不触达；
+	// 无 SDK 的 CI 构建里 ClangCL -Werror、-Wunused-private-field 会报错
+	[[maybe_unused]] uint32_t _activeConsumers = 0;
+	[[maybe_unused]] uint32_t _activeParameterBlocks = 0;
+	[[maybe_unused]] bool _initialized = false;
 };
 
 }

--- a/src/Magpie.Core/NvidiaOpticalFlowProvider.h
+++ b/src/Magpie.Core/NvidiaOpticalFlowProvider.h
@@ -29,7 +29,8 @@ public:
 	OpticalFlowInitializationError InitializationError() const noexcept override;
 
 private:
-	NvidiaOpticalFlowQuality _quality;
+	// 仅在 MP_ENABLE_NVIDIA_OPTICAL_FLOW 构建中使用；无 SDK 的 CI 构建里 ClangCL -Werror 会报未使用
+	[[maybe_unused]] NvidiaOpticalFlowQuality _quality;
 	std::unique_ptr<Impl> _impl;
 };
 

--- a/src/Magpie.Core/OverlayDrawer.cpp
+++ b/src/Magpie.Core/OverlayDrawer.cpp
@@ -1446,8 +1446,9 @@ bool OverlayDrawer::_DrawEffectParameters(int& itemId) noexcept {
 			std::string(GetEffectDisplayName(description)).c_str());
 
 		std::string_view currentGroup;
-		uint32_t validCount = 0;
-		uint32_t invalidCount = 0;
+		// 仅在 _DEBUG 下读取（参数元数据一致性告警），release 下以 maybe_unused 抑制 ClangCL -Werror
+		[[maybe_unused]] uint32_t validCount = 0;
+		[[maybe_unused]] uint32_t invalidCount = 0;
 		for (size_t parameterIdx = 0;
 			parameterIdx < description.params.size(); ++parameterIdx) {
 			const EffectParameterDesc& parameter =

--- a/src/Magpie.Core/RTXVideoDenoiser.h
+++ b/src/Magpie.Core/RTXVideoDenoiser.h
@@ -33,8 +33,9 @@ public:
 
 private:
 	struct Impl;
-	std::unique_ptr<Impl> _impl;
-	uint32_t _qualityLevel = 8;
+	// 仅在 MP_ENABLE_RTX_VIDEO_DENOISE 构建中使用；无 SDK 的 CI 构建里 ClangCL -Werror 会报未使用
+	[[maybe_unused]] std::unique_ptr<Impl> _impl;
+	[[maybe_unused]] uint32_t _qualityLevel = 8;
 	ScalingError _initializationError = ScalingError::NoError;
 };
 

--- a/src/Magpie.Core/Renderer.cpp
+++ b/src/Magpie.Core/Renderer.cpp
@@ -2620,7 +2620,7 @@ HANDLE Renderer::_InitBackend() noexcept {
 	}
 
 	if (guidanceRequirements.Any()) {
-		guidanceRequirements.ForEachMotion([&](MotionVectorRequest request) {
+		guidanceRequirements.ForEachMotion([&]([[maybe_unused]] MotionVectorRequest request) {
 #ifdef MP_ENABLE_NVIDIA_OPTICAL_FLOW
 			if (request.method == OpticalFlowMethod::Nvidia)
 				_frameGuidanceService.SetMotionVectorProvider(request,

--- a/src/Magpie.Core/ScalingWindow.cpp
+++ b/src/Magpie.Core/ScalingWindow.cpp
@@ -464,6 +464,8 @@ void ScalingWindow::_CompleteFrontendRender(
 		_isFirstFrame = false;
 		// 第一帧渲染完成后显示缩放窗口
 		_Show();
+		// 缩放已开始，给用户一个确认；失败路径已有错误提示
+		ShowToast(GetLocalizedString(L"Message_ScalingStarted"));
 		const auto& notice = _renderer->MotionConfigurationNotice();
 		if (!notice.empty()) ShowToast(notice);
 	}

--- a/src/Magpie.Core/XeSSFGPresenter.h
+++ b/src/Magpie.Core/XeSSFGPresenter.h
@@ -61,10 +61,11 @@ protected:
 private:
 	bool _ResizeOverlaySurface() noexcept;
 
-	std::unique_ptr<Impl> _impl;
-	XeSSFGVariant _variant = XeSSFGVariant::X2;
-	uint32_t _requestedMultiplier = 2;
-	bool _useExternalMotion = false;
+	// 仅在 MP_ENABLE_XESS_FRAME_GENERATION 构建中使用；无 SDK 的 CI 构建里 ClangCL -Werror 会报未使用
+	[[maybe_unused]] std::unique_ptr<Impl> _impl;
+	[[maybe_unused]] XeSSFGVariant _variant = XeSSFGVariant::X2;
+	[[maybe_unused]] uint32_t _requestedMultiplier = 2;
+	[[maybe_unused]] bool _useExternalMotion = false;
 	ScalingError _initializationError = ScalingError::ScalingFailedGeneral;
 };
 

--- a/src/Magpie.Core/XeSSUpscaler.h
+++ b/src/Magpie.Core/XeSSUpscaler.h
@@ -42,7 +42,8 @@ public:
 
 private:
 	MotionVectorRequest _motionRequest{};
-	std::unique_ptr<Impl> _impl;
+	// 仅在 MP_ENABLE_XESS_ZEROMV 构建中使用；无 SDK 的 CI 构建里 ClangCL -Werror 会报未使用
+	[[maybe_unused]] std::unique_ptr<Impl> _impl;
 };
 
 }

--- a/src/Magpie/AboutPage.cpp
+++ b/src/Magpie/AboutPage.cpp
@@ -24,15 +24,15 @@ void AboutPage::VersionTextBlock_DoubleTapped(IInspectable const&, Input::Double
 }
 
 void AboutPage::BugReport_Click(IInspectable const&, RoutedEventArgs const&) {
-	Win32Helper::ShellOpen(L"https://github.com/Blinue/Magpie/issues/new?assignees=&labels=bug&template=01_bug.yaml");
+	Win32Helper::ShellOpen(L"https://github.com/SAOG0721/Magpie/issues/new?assignees=&labels=bug&template=01_bug.yaml");
 }
 
 void AboutPage::FeatureRequest_Click(IInspectable const&, RoutedEventArgs const&) {
-	Win32Helper::ShellOpen(L"https://github.com/Blinue/Magpie/issues/new?assignees=&labels=enhancement&template=03_request.yaml");
+	Win32Helper::ShellOpen(L"https://github.com/SAOG0721/Magpie/issues/new?assignees=&labels=enhancement&template=03_request.yaml");
 }
 
 void AboutPage::Discussions_Click(IInspectable const&, RoutedEventArgs const&) {
-	Win32Helper::ShellOpen(L"https://github.com/Blinue/Magpie/discussions");
+	Win32Helper::ShellOpen(L"https://github.com/SAOG0721/Magpie/discussions");
 }
 
 void AboutPage::InfoBar_SizeChanged(IInspectable const& sender, SizeChangedEventArgs const&) const {

--- a/src/Magpie/HomeViewModel.cpp
+++ b/src/Magpie/HomeViewModel.cpp
@@ -375,9 +375,9 @@ fire_and_forget HomeViewModel::IsTouchSupportEnabled(bool value) {
 
 Uri HomeViewModel::TouchSupportLearnMoreUrl() const noexcept {
 	if (LocalizationService::Get().Language() == L"zh-hans"sv) {
-		return Uri(L"https://github.com/Blinue/Magpie/blob/dev/docs/%E5%85%B3%E4%BA%8E%E8%A7%A6%E6%8E%A7%E6%94%AF%E6%8C%81.md");
+		return Uri(L"https://github.com/SAOG0721/Magpie/blob/experimental/docs/%E5%85%B3%E4%BA%8E%E8%A7%A6%E6%8E%A7%E6%94%AF%E6%8C%81.md");
 	} else {
-		return Uri(L"https://github.com/Blinue/Magpie/blob/dev/docs/About%20touch%20support.md");
+		return Uri(L"https://github.com/SAOG0721/Magpie/blob/experimental/docs/About%20touch%20support.md");
 	}
 }
 

--- a/src/Magpie/PageFrame.xaml
+++ b/src/Magpie/PageFrame.xaml
@@ -90,6 +90,7 @@
 		              IsTabStop="True"
 		              KeyDown="ScrollViewer_KeyDown"
 		              PointerPressed="ScrollViewer_PointerPressed"
+		              HorizontalScrollBarVisibility="Disabled"
 		              VerticalScrollBarVisibility="Auto"
 		              ViewChanging="ScrollViewer_ViewChanging">
 			<ContentControl Grid.Column="0"

--- a/src/Magpie/Resources.language-en-US.resw
+++ b/src/Magpie/Resources.language-en-US.resw
@@ -823,6 +823,9 @@
   <data name="Message_ScalingFailed" xml:space="preserve">
     <value>Could not enable effect group</value>
   </data>
+  <data name="Message_ScalingStarted" xml:space="preserve">
+    <value>Scaling started. Press the scaling shortcut again to stop.</value>
+  </data>
   <data name="Profile_Performance_NoGraphicsCard.Title" xml:space="preserve">
     <value>No compatible graphics card was found, so slower CPU rendering will be used. Make sure your graphics driver is installed and up to date.</value>
   </data>

--- a/src/Magpie/Resources.language-zh-Hans.resw
+++ b/src/Magpie/Resources.language-zh-Hans.resw
@@ -823,6 +823,9 @@
   <data name="Message_ScalingFailed" xml:space="preserve">
     <value>无法启用效果组</value>
   </data>
+  <data name="Message_ScalingStarted" xml:space="preserve">
+    <value>缩放已开始，再次按下缩放快捷键停止</value>
+  </data>
   <data name="Profile_Performance_NoGraphicsCard.Title" xml:space="preserve">
     <value>找不到兼容的显卡，将使用性能较低的 CPU 渲染。请确认显卡驱动已经正确安装并更新。</value>
   </data>

--- a/src/Magpie/Resources.language-zh-Hant.resw
+++ b/src/Magpie/Resources.language-zh-Hant.resw
@@ -721,6 +721,9 @@
   <data name="Message_ScalingFailed" xml:space="preserve">
     <value>無法啟用效果組</value>
   </data>
+  <data name="Message_ScalingStarted" xml:space="preserve">
+    <value>縮放已開始，再按一次縮放捷徑停止</value>
+  </data>
   <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Content" xml:space="preserve">
     <value>啟用動態偵測統計</value>
   </data>

--- a/src/Magpie/RootPage.h
+++ b/src/Magpie/RootPage.h
@@ -129,7 +129,8 @@ private:
 	::Magpie::Event<uint32_t>::EventRevoker _profileRenamedRevoker;
 	::Magpie::Event<uint32_t>::EventRevoker _profileRemovedRevoker;
 	::Magpie::Event<uint32_t, uint32_t>::EventRevoker _profileMovedRevoker;
-	Primitives::FlyoutBase::Opening_revoker _contextFlyoutOpeningRevoker;
+	// 当前未被任何代码读取（Opening 事件钩子未接线）；ClangCL -Werror、-Wunused-private-field 会报错
+	[[maybe_unused]] Primitives::FlyoutBase::Opening_revoker _contextFlyoutOpeningRevoker;
 
 	Button _profileMoreOptionsButton{ nullptr };
 	FrameworkElement _profileReorderHandle{ nullptr };

--- a/src/Magpie/SettingsGroup.Resource.xaml
+++ b/src/Magpie/SettingsGroup.Resource.xaml
@@ -38,12 +38,13 @@
 						                  Margin="1,0,0,0"
 						                  Content="{TemplateBinding Description}"
 						                  Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-						                  TextWrapping="WrapWholeWords">
+						                  TextWrapping="Wrap">
 							<ContentPresenter.Resources>
 								<Style BasedOn="{StaticResource CaptionTextBlockStyle}"
 								       TargetType="TextBlock">
 									<Style.Setters>
-										<Setter Property="TextWrapping" Value="WrapWholeWords" />
+										<!-- CJK 文本无词边界，WrapWholeWords 会导致窄窗口下整句截断 -->
+										<Setter Property="TextWrapping" Value="Wrap" />
 									</Style.Setters>
 								</Style>
 								<Style BasedOn="{StaticResource TextButtonStyle}"

--- a/tests/consistency/README.md
+++ b/tests/consistency/README.md
@@ -1,0 +1,28 @@
+# Consistency checks
+
+Zero-dependency (Python 3.11+ stdlib) repository consistency checks. They encode
+rules that are already documented by the maintainers
+(`docs/experimental/RELEASE-WORKFLOW.md`, `docs/EXPERIMENTAL_HANDOFF_ZH.md`) so
+mechanical drift is caught before a release or PR, not during it.
+
+```powershell
+python tests/consistency/run.py
+# exit code 1 on any FAIL; --json writes consistency-report.json
+```
+
+Rules:
+
+| Rule | Level semantics | What it checks |
+| --- | --- | --- |
+| R1 | FAIL/WARN | `version.json` vs `docs/RELEASE_NOTES_NEXT.md` — the version NEXT points at must not already be released (still marked 草稿/draft) |
+| R2 | FAIL | main `RELEASE_NOTES_v*-experimental.md` files keep the bilingual structure (Chinese block, `---`, English block) |
+| R3 | FAIL/WARN | `presets/*.json` reference existing `src/Effects/**.hlsl` files, and their parameter keys exist in the effect's `//!PARAMETER` metadata. Keys that `ScalingModesService` migrates at load time (the V065 normalization table, mirrored here) are WARN; keys in neither place would be silently ignored by the runtime and stay FAIL |
+| R4 | FAIL/INFO/WARN | every `Resources.language-*.resw` parses, has no duplicate keys; per-language coverage vs en-US is reported (zh-* gaps are WARN; other languages INFO). Translations themselves are managed on Weblate — this suite never edits them |
+| R5 | INFO/WARN | effect-parameter label keys (`ScalingModes_EffectParam_<effect>_<param>`, PR #16 convention) — coverage report |
+| R6 | FAIL/INFO | XAML `x:Uid` references must exist in en-US; en-US keys with zero code/XAML references are listed as cleanup candidates (maintainer decision — resw files are Weblate-managed) |
+| R7 | FAIL/WARN | relative links in `docs/**` resolve to real files (angle-bracket and space-containing targets supported; fragments and absolute local paths like `C:/...` ignored). Dated review records under `docs/**/reviews/` may legitimately point at files a later refactor renamed, so missing targets there are WARN |
+| R8 | FAIL | files referenced by `.github/workflows/build.yml` exist |
+| R9 | FAIL | `scripts/Build-Release.ps1` keeps the required runtime layout entries |
+
+Adding a rule = one function named `rN_*` plus one entry in `RULES`. A rule that
+crashes is reported as FAIL rather than silently skipped.

--- a/tests/consistency/run.py
+++ b/tests/consistency/run.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Magpie repo consistency checks (stdlib only, Python 3.11+).
+
+Runs declarative consistency rules over the repository. These checks encode
+rules already documented by the maintainers (docs/experimental/RELEASE-WORKFLOW.md,
+docs/EXPERIMENTAL_HANDOFF_ZH.md, effect metadata conventions) so that release
+preparation catches mechanical drift before a release or PR.
+
+Usage:
+    python tests/consistency/run.py [--json]
+
+Exit code is 1 when any rule has a FAIL finding, else 0.
+Rules report three levels:
+  FAIL  — breaks a documented rule; must be fixed (or the rule adjusted) before merge/release.
+  WARN  — suspicious; maintainer decision required (e.g. files owned by Weblate or the
+          release process are reported but never auto-edited).
+  INFO  — informational counters (e.g. translation coverage per language).
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class Findings:
+    def __init__(self):
+        self.items: list[tuple[str, str, str]] = []  # (rule, level, message)
+
+    def add(self, rule: str, level: str, message: str) -> None:
+        self.items.append((rule, level, message))
+
+    def has_fail(self) -> bool:
+        return any(level == 'FAIL' for _, level, _ in self.items)
+
+
+def read_text(p: Path) -> str:
+    return p.read_text(encoding='utf-8', errors='replace')
+
+
+# R1: version.json must not equal a version that RELEASE_NOTES_NEXT still
+# marks as a draft ("草稿"/"尚未发布"). The next version is taken from the
+# RELEASE_NOTES_v*-experimental.md reference in NEXT.
+def r1_next_doc_stale(f: Findings) -> None:
+    vj = json.loads(read_text(ROOT / 'version.json'))
+    nxt = read_text(ROOT / 'docs' / 'RELEASE_NOTES_NEXT.md')
+    m = re.search(r'RELEASE_NOTES_v([0-9.]+)-experimental\.md', nxt)
+    if not m:
+        f.add('R1', 'WARN', 'RELEASE_NOTES_NEXT.md 中找不到 RELEASE_NOTES_v*-experimental.md 引用')
+        return
+    declared = 'v' + m.group(1)
+    is_draft = any(k in nxt for k in ('草稿', '尚未发布', '未发布', 'draft'))
+    if declared == vj['tag'] and is_draft:
+        f.add('R1', 'WARN',
+              f'NEXT 文档仍把已发布的 {declared} 标为草稿(version.json.tag 已指向它)——'
+              '按发布记录维护规范应更新 NEXT 文档(作者例行簿记,非 PR 代劳项)')
+    else:
+        f.add('R1', 'INFO', f"version.json={vj['tag']}; NEXT 指向下一版本={declared}")
+
+
+# R2: main experimental release notes are bilingual. Accepted conventions:
+#   a) Chinese block + '---' separator + English block (current standard), or
+#   b) '## 中文' and '## English' (older files), or '## English quick guide'.
+# Files explicitly marked as never-published drafts only WARN.
+def r2_release_notes_bilingual(f: Findings) -> None:
+    for p in sorted((ROOT / 'docs').glob('RELEASE_NOTES_v*-experimental.md')):
+        txt = read_text(p)
+        has_zh = len(re.findall(r'[一-鿿]', txt)) > 200
+        has_en = ('## English' in txt or '## English quick guide' in txt
+                  or txt.count('# Magpie Experimental') >= 2)
+        if has_zh and has_en:
+            continue
+        is_draft = ('未发布' in txt or 'never officially released' in txt.lower())
+        level = 'WARN' if is_draft else 'FAIL'
+        f.add('R2', level, f'{p.name} 双语结构不完整(zh={has_zh}, en={has_en})')
+
+
+# R3: presets reference existing effect files, and preset parameter keys must
+# match the parameter variable names declared in the effect metadata.
+# Metadata blocks: //!PARAMETER, then any //!-directive lines (//!GROUP,
+# //!LABEL, //!DEFAULT, //!OPTION, ...), then the variable declaration.
+_PARAM_RE = re.compile(r'//!PARAMETER\s*\n(?://![^\n]*\n)+(\w+) (\w+)\s*;')
+
+
+def _effect_params(effect_file: Path) -> set[str]:
+    txt = read_text(effect_file)
+    return {m.group(2) for m in _PARAM_RE.finditer(txt)}
+
+
+# Keys that ScalingModesService (V065 normalization, ScalingModesService.cpp)
+# migrates or removes at load time. Preset files still carrying them are not
+# silently ignored, so they only WARN; keys absent from both metadata and this
+# table are silently dropped by the runtime and stay FAIL.
+_R3_MIGRATED = {
+    'useMotionVectors', 'useEstimatedDepth',  # DLSSFG/DLSSNR/DLSS-SR 光流选择迁移
+    'motionVectorQuality',                    # DLSS/DLSSFG/DLSSNR 旧光流质量键
+    'nrPreset', 'guidanceMode', 'depthInferenceInterval',  # DLSSNR 旧键(删除/迁移)
+    'enableJitter',                           # SR 标记变体合并
+}
+
+
+def r3_presets(f: Findings) -> None:
+    for p in sorted((ROOT / 'presets').glob('*.json')):
+        data = json.loads(read_text(p))
+        for mode in data.get('scalingModes', []):
+            for eff in mode.get('effects', []):
+                name = eff['name'].replace('\\', '/')
+                cand = ROOT / 'src' / 'Effects' / (name + '.hlsl')
+                if not cand.is_file():
+                    f.add('R3', 'FAIL', f'{p.name}: 效果不存在 src/Effects/{name}.hlsl')
+                    continue
+                declared = _effect_params(cand)
+                for key in (eff.get('parameters') or {}):
+                    if key in declared:
+                        continue
+                    if key in _R3_MIGRATED:
+                        f.add('R3', 'WARN',
+                              f'{p.name}: {mode["name"]} → {eff["name"]} 的参数键 "{key}" '
+                              '不在效果元数据中,但运行时归一化会迁移它(见 ScalingModesService)')
+                        continue
+                    f.add('R3', 'FAIL',
+                          f'{p.name}: {mode["name"]} → {eff["name"]} 的参数键 "{key}" '
+                          f'在效果元数据中不存在(声明了:{sorted(declared)})——该键会被静默忽略')
+
+
+# R4: resw structural integrity + per-language coverage.
+def r4_resw(f: Findings) -> None:
+    langs: dict[str, set[str]] = {}
+    for p in sorted((ROOT / 'src' / 'Magpie').glob('Resources.language-*.resw')):
+        lang = p.stem.split('language-')[1]
+        try:
+            tree = ET.parse(p)
+        except ET.ParseError as e:
+            f.add('R4', 'FAIL', f'{p.name}: XML 解析失败 {e}')
+            continue
+        names = [d.attrib['name'] for d in tree.getroot().iter('data')]
+        dup = {n for n in names if names.count(n) > 1}
+        if dup:
+            f.add('R4', 'FAIL', f'{p.name}: 重复 data 键 {sorted(dup)}')
+        langs[lang] = set(names)
+    ref = langs.get('en-US')
+    if ref is None:
+        f.add('R4', 'FAIL', '缺少 Resources.language-en-US.resw')
+        return
+    for lang, keys in sorted(langs.items()):
+        missing = len(ref - keys)
+        level = 'INFO' if lang not in ('zh-Hans', 'zh-Hant') else ('WARN' if missing else 'INFO')
+        f.add('R4', level, f'{lang}: 缺少 {missing}/{len(ref)} 个键'
+              + ('（翻译走 Weblate，勿在 PR 中补译文）' if missing else ''))
+
+
+# R5: effect parameter label keys (PR #16 convention) consistency.
+def r5_effect_param_labels(f: Findings) -> None:
+    effects: dict[str, list[str]] = {}
+    for p in sorted((ROOT / 'src' / 'Effects').rglob('*.hlsl')):
+        txt = read_text(p)
+        params = [m.group(2) for m in _PARAM_RE.finditer(txt)]
+        if params:
+            rel = p.relative_to(ROOT / 'src' / 'Effects').with_suffix('').as_posix()
+            effects[rel] = params
+    if not effects:
+        f.add('R5', 'WARN', '未解析到任何效果参数(检查正则是否与 !PARAMETER 元数据格式匹配)')
+        return
+    en = read_text(ROOT / 'src' / 'Magpie' / 'Resources.language-en-US.resw')
+    total = sum(len(v) for v in effects.values())
+    have = 0
+    for rel, params in effects.items():
+        for param in params:
+            key = 'ScalingModes_EffectParam_' + rel.replace('/', '_') + '_' + param
+            if key in en:
+                have += 1
+    f.add('R5', 'INFO',
+          f'效果参数 {total} 个;en-US 已有本地化键 {have} 个(PR#16 合入前为 0 属预期)')
+
+
+# R6: resource key usage — references without definitions are FAIL;
+# definitions without references are INFO (candidate cleanup; resw files are
+# Weblate-managed, so removal is a maintainer decision).
+def r6_resource_usage(f: Findings) -> None:
+    tree = ET.parse(ROOT / 'src' / 'Magpie' / 'Resources.language-en-US.resw')
+    names = [d.attrib['name'] for d in tree.getroot().iter('data')]
+
+    def stem_of(name: str) -> str:
+        # XAML Uid conventions: "<Uid>.<Property>", or
+        # "<Uid>.[using:...]ToolTipService.ToolTip" (attached property).
+        i = name.find('.[using:')
+        if i > 0:
+            return name[:i]
+        return name.rsplit('.', 1)[0] if '.' in name else name
+
+    stems = {stem_of(n) for n in names}
+    corpus = ''
+    for p in (ROOT / 'src' / 'Magpie').rglob('*'):
+        if p.suffix.lower() in ('.xaml', '.cpp', '.h', '.idl', '.cs'):
+            corpus += read_text(p) + '\n'
+    unreferenced = sorted(s for s in stems if s not in corpus)
+    for s in unreferenced:
+        f.add('R6', 'INFO', f'资源键无引用(废弃候选,Weblate/作者决策):{s}')
+    # reverse direction: x:Uid referenced stems must exist in en-US
+    uids = set(re.findall(r'x:Uid="([^"]+)"', corpus))
+    for u in sorted(uids):
+        if u not in stems:
+            f.add('R6', 'FAIL', f'XAML 引用了 en-US 中不存在的键:{u}')
+
+
+# R7: relative links in docs/** must resolve. Dated review records
+# (docs/**/reviews/) may point at files that later refactors renamed, so a
+# missing target there is WARN, not FAIL; living docs stay FAIL. Web links and
+# absolute local paths (C:/...) are outside the repo-relative contract.
+def r7_doc_links(f: Findings) -> None:
+    link_re = re.compile(r'\[[^\]]*\]\(<([^>]+)>\)|\[[^\]]*\]\(([^)\s]+)\)')
+    for p in sorted((ROOT / 'docs').rglob('*.md')):
+        is_review = '/reviews/' in p.as_posix()
+        for m in link_re.finditer(read_text(p)):
+            target = (m.group(1) or m.group(2)).split('#', 1)[0]
+            if re.match(r'[a-z]+://', target) or re.match(r'^[A-Za-z]:[/\\]', target):
+                continue
+            if not (p.parent / target).exists():
+                level = 'WARN' if is_review else 'FAIL'
+                f.add('R7', level, f'{p.relative_to(ROOT)}: 死链 {target}'
+                      + ('(历史评审记录,目标文件可能已被重构)' if is_review else ''))
+
+
+# R8: files referenced by CI workflow must exist.
+def r8_ci_refs(f: Findings) -> None:
+    wf = read_text(ROOT / '.github' / 'workflows' / 'build.yml')
+    for path in ('Magpie.slnx', 'scripts/publish.py'):
+        if path in wf and not (ROOT / path).is_file():
+            f.add('R8', 'FAIL', f'build.yml 引用不存在:{path}')
+
+
+# R9: release script keeps the required runtime layout list.
+def r9_release_layout(f: Findings) -> None:
+    ps = read_text(ROOT / 'scripts' / 'Build-Release.ps1')
+    for needle in ('"Magpie.exe"', '"resources.pri"', '"TouchHelper.exe"', '"Updater.exe"'):
+        if needle not in ps:
+            f.add('R9', 'FAIL', f'Build-Release.ps1 的运行时清单缺少 {needle}')
+
+
+RULES = [
+    ('R1', r1_next_doc_stale),
+    ('R2', r2_release_notes_bilingual),
+    ('R3', r3_presets),
+    ('R4', r4_resw),
+    ('R5', r5_effect_param_labels),
+    ('R6', r6_resource_usage),
+    ('R7', r7_doc_links),
+    ('R8', r8_ci_refs),
+    ('R9', r9_release_layout),
+]
+
+
+def main() -> int:
+    f = Findings()
+    for rule_id, fn in RULES:
+        try:
+            fn(f)
+        except Exception as e:  # a crashing rule is itself a FAIL
+            f.add(rule_id, 'FAIL', f'规则执行异常:{type(e).__name__}: {e}')
+    for rule, level, msg in f.items:
+        print(f'[{level:4}] {rule}: {msg}')
+    n_fail = sum(1 for _, lv, _ in f.items if lv == 'FAIL')
+    n_warn = sum(1 for _, lv, _ in f.items if lv == 'WARN')
+    n_info = sum(1 for _, lv, _ in f.items if lv == 'INFO')
+    print(f'\nFAIL={n_fail} WARN={n_warn} INFO={n_info}')
+    if '--json' in sys.argv:
+        out = {'fail': n_fail, 'warn': n_warn, 'info': n_info,
+               'items': [{'rule': r, 'level': lv, 'message': m} for r, lv, m in f.items]}
+        Path(sys.argv[-1] if sys.argv[-1].endswith('.json') else
+             'consistency-report.json').write_text(json.dumps(out, ensure_ascii=False, indent=2),
+                                                   encoding='utf-8')
+    return 1 if f.has_fail() else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## 概述

本 PR 来自 fork（TurnX-alt/Magpie），基于 upstream/experimental 最新提交 9824d758。84d9f6ab 之后的改动（SR 变体合并、V065 参数归一化、ErrorService 报告链路）已全部按新树重做，无冲突。共 6 个 commit，每个可单独 review。

## 内容

### fix(build): ClangCL no-SDK 构建 -Werror 报错（核心）

upstream/experimental @ 9824d758 的 CI（run 34140771326）在 ClangCL/ARM64 失败；修复按 CI 日志逐轮收敛（中途 run 34141785217 / 34142324280 / 34142826247 各暴露一批）：

1. OverlayDrawer.cpp：validCount / invalidCount 只在 `#ifdef _DEBUG` 读取，-Wunused-but-set-variable → 声明加 `[[maybe_unused]]`
2. Renderer.cpp：`ForEachMotion` lambda 参数 `request` 在 NVIDIA/AMD OF 两个宏都关闭时未使用，-Wunused-parameter → 加 `[[maybe_unused]]`
3. 10 个门控后端头文件 54 个私有字段只在 SDK 分支使用，桩构建报 -Wunused-private-field：DLSSSRUpscaler（16）、FSR2Upscaler（23）、FSR3Upscaler（2）、XeSSUpscaler（1）、DLSSFrameGenerator（1）、DLSSNRFilter（3）、RTXVideoDenoiser（2）、XeSSFGPresenter（4）、AmdOpticalFlowProvider（1）、NvidiaOpticalFlowProvider（1），逐字段核对桩分支触达后标注（桩构造函数初始化列表不算使用）
4. NgxD3D12Core 的 `_activeConsumers` / `_activeParameterBlocks` / `_initialized` 只在其他 TU 的 SDK 分支读取，本 TU 不触达，同样标注
5. 两个全仓库零引用的私有字段（上游遗留，未删，标注后留待作者处置）：AdaptivePresenter._frameLatencyWaitTimeoutCount、RootPage._contextFlyoutOpeningRevoker

### fix(presets): v0.5.7 preset 的 frameMultiplier 键

效果元数据已把 DLSSFG 的 `frameMultiplier` 改名 `multiplier`，v0.5.7 preset 仍写旧键。V065 归一化没有这条迁移路径，载入时被静默忽略（当前值 2 恰好等于默认值，所以无感）。改为 `multiplier`。其余旧键（useMotionVectors / nrPreset / guidanceMode 等）有归一化迁移，未动。

### fix(ui): 窄窗口内容裁剪 + CJK 描述换行

1. PageFrame.xaml：滚动容器补 `HorizontalScrollBarVisibility="Disabled"`
2. SettingsGroup.Resource.xaml：描述文本 `WrapWholeWords` → `Wrap`。中文整句没有词边界，窄窗口下断不了行，整句被截断

### fix(links): 反馈入口与触控文档指向本 fork

About 页三个入口（BugReport / FeatureRequest / Discussions）和触控支持文档链接仍指向 Blinue/Magpie；本仓库默认分支是 experimental（dev 是分叉的旧线），触控文档改指 experimental。

### feat(ux): 缩放开始时 toast

首帧渲染完成、缩放窗口显示后弹「缩放已开始，再次按下缩放快捷键停止」（Message_ScalingStarted，en-US / zh-Hans / zh-Hant）。上游已有失败侧提示（DlssNrUnavailable 等走 ErrorService），这里只补成功侧确认。文案无占位符。

### test: 一致性检查套件

tests/consistency/run.py，零依赖（Python 3.11 标准库），9 条规则（R1-R9）：

- R1-R2：版本/NEXT 文档、release notes 双语结构
- R3：preset 参数键对照效果 `//!PARAMETER` 元数据，并镜像 V065 归一化迁移表——有迁移路径的旧键报 WARN，两处都没有的键会被静默忽略，报 FAIL
- R4-R6：resw 结构/多语言覆盖、效果参数本地化键、x:Uid 引用
- R7：docs 相对链接（尖括号、含空格路径、`#L` 片段、`C:/` 绝对路径均处理；历史评审记录的死链只报 WARN）
- R8-R9：CI 引用的文件、Build-Release.ps1 运行时清单

当前基线 0 FAIL / 22 WARN（R4：zh-Hant 缺 11 键，走 Weblate；R7：评审记录指向已重构文件）。

## 验证

- python tests/consistency/run.py：0 FAIL
- fork CI 全矩阵（MSVC/ClangCL × x64/ARM64）：4/4 绿（最终 run 34150899357）
- 红基线：纯 upstream/experimental @ 9824d758 的 CI run 34140771326，ClangCL/ARM64 失败，其余任务 fail-fast 取消