### PR TITLE
feat(XeSS): remove vendor and capability gate on multi-frame generation multiplier

### DIFF
--- a/src/Magpie.Core/Renderer.cpp
+++ b/src/Magpie.Core/Renderer.cpp
@@ -429,12 +429,6 @@ ScalingError Renderer::Initialize(HWND hwndAttach, OverlayOptions& overlayOption
 			xessFrameGenerationMultiplier, adapterDesc.VendorId,
 			adapterDesc.DeviceId, static_cast<uint32_t>(_xessMotionRequest.method),
 			static_cast<uint32_t>(_xessMotionRequest.quality)));
-		if (xessFrameGenerationMultiplier > 2 &&
-			adapterDesc.VendorId != 0x8086) {
-			Logger::Get().Error(
-				"XeSS Multi-Frame Generation x3/x4 requires an Intel adapter");
-			return ScalingError::XeSSMfgRequiresIntel;
-		}
 
 		auto xessPresenter = std::make_unique<XeSSFGPresenter>(
 			*xessVariant,

--- a/src/Magpie.Core/XeSSFGPresenter.cpp
+++ b/src/Magpie.Core/XeSSFGPresenter.cpp
@@ -550,15 +550,6 @@ bool XeSSFGPresenter::_Initialize(HWND hwndAttach) noexcept {
 		"maxSupportedInterpolations={}",
 		_variant == XeSSFGVariant::X2 ? "x2" : "MFG",
 		_requestedMultiplier, properties.maxSupportedInterpolations));
-	if (properties.maxSupportedInterpolations < requestedInterpolations) {
-		Logger::Get().Error(fmt::format(
-			"XeSSFG {}x is unsupported: hardware supports at most {}x",
-			_requestedMultiplier, properties.maxSupportedInterpolations + 1));
-		_initializationError = _requestedMultiplier > 2 ?
-			ScalingError::XeSSMfgMultiplierUnsupported :
-			ScalingError::ScalingFailedGeneral;
-		return false;
-	}
 	const uint32_t interpolatedFrames = requestedInterpolations;
 	impl->multiplier = _requestedMultiplier;
 


### PR DESCRIPTION
## 改动内容
- `Renderer.cpp`：移除 `xessFrameGenerationMultiplier > 2 && VendorId != 0x8086` 的硬性拦截
- `XeSSFGPresenter.cpp`：移除 `maxSupportedInterpolations < requestedInterpolations` 的能力拦截

## 动机
允许非 Intel 显卡在配合社区版 XeSS-MFG 获得更高的多帧生成倍率，失败时按现有错误路径回退，而不是直接被拦截。

## 测试
RTX 3060，配合社区版 XeSS-MFG 运行时，x2/x3/x4 多帧生成可启用。